### PR TITLE
Add missing apps to search rebuild script

### DIFF
--- a/search.py
+++ b/search.py
@@ -4,6 +4,7 @@ import util
 
 SEARCHABLE_APPS = {
     'calendars':             ('frontend', ['panopticon:register']),
+    'designprinciples':      ('frontend', ['rummager:index']), # Includes the service-manual. Note: not included in gov.uk/search
     'frontend':              ('frontend', ['rummager:index']),
     'licencefinder':         ('frontend', ['panopticon:register']),
     'businesssupportfinder': ('frontend', ['panopticon:register']),


### PR DESCRIPTION
This script is missing various apps.

I've added Design Principles/Service Manual, although it is not included in gov.uk/search results, whereas the others included here are.

It's worth noting that Trade Tariff registers it's homepage with Panopticon, but also uses Elasticsearch directly. Needotron is similar. I'm ignoring that for now.
