### PR TITLE
It was taking too long to turn it off & on again

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -10,6 +10,11 @@ def gracefulstop(wait=True):
         run('while pgrep nginx >/dev/null; do echo "Waiting for Nginx to exit.."; sleep 1; done')
 
 @task
+def killnginx():
+    """Shut down Nginx immediately without waiting for it to finish running"""
+    sudo('service nginx stop')
+
+@task
 def gracefulstart():
     """Start up Nginx on a machine"""
     sudo('service nginx start')
@@ -17,5 +22,5 @@ def gracefulstart():
 @task
 def hello_it():
     """Turns Nginx off and on again"""
-    gracefulstop()
+    killnginx()
     gracefulstart()


### PR DESCRIPTION
The graceful stop waits for running processes to finish but when we have an
alert where we have too many connections this is not ideal - we just want to
kill it quickly.

This commit adds a task to kill it and makes that what is called in the hello_it
(have you tried turning it off and on again?) task.
