### PR TITLE
Add a fabric script to restart all the logstreams on a machine.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -15,6 +15,7 @@ import apt
 import cache
 import es
 import licensify
+import logstream
 import mongo
 import nginx
 import ntp

--- a/logstream.py
+++ b/logstream.py
@@ -1,0 +1,7 @@
+from fabric.api import *
+
+@task
+def restart_all():
+    """Restart all the logstreams on a machine"""
+    sudo("for logstream in `ls /etc/init/logstream*`; do BASE=`basename $logstream .conf`; service $BASE restart; done")
+


### PR DESCRIPTION
It would seem that while logstream will recover 20 minutes after a network outage it would be better if we could get stats quicker.
