### PR TITLE
Force deletion of the `reboot-required` file.

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -18,4 +18,4 @@ def packages_with_reboots(*args):
 @task
 def reset_reboot_needed(*args):
     """Delete the flag file that triggers the 'reboot required by apt' Nagios check"""
-    sudo('rm /var/run/reboot-required')
+    sudo('rm -f /var/run/reboot-required')


### PR DESCRIPTION
Without this flag, any machines that don't have the file present will cause the task to fail, so we have to remember to pass the `-w` flag to Fabric if we're going to do a reset on a whole class of machines.

Passing `-f` to `rm` instead of using the `warn_only` Fabric option because we don't want to suppress failed attempts  to delete a file when it does exist.
