### PR TITLE
Add nagios.schedule_downtime command

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -17,6 +17,7 @@ import es
 import licensify
 import logstream
 import mongo
+import nagios
 import nginx
 import ntp
 import puppet

--- a/nagios.py
+++ b/nagios.py
@@ -1,0 +1,36 @@
+from StringIO import StringIO
+
+from fabric.api import *
+#from fabric.contrib.files import append
+
+
+NAGIOS_CMD_FILE = '/var/lib/nagios3/rw/nagios.cmd'
+
+
+def submit_nagios_cmd(command):
+    # ugh, double-formatted string
+    sudo("printf '[%%lu] %s\n' `date +%%s` >> %s" % (command, NAGIOS_CMD_FILE))
+
+
+@task
+@hosts(['monitoring.management'])
+def schedule_downtime(host,minutes='20'):
+    """Schedules downtime for a host in nagios; default for 20 minutes"""
+
+    # get timestamp from monitoring server to avoid clock skew issues.
+    timestamp = int(run("date +%s"))
+    minutes = int(minutes)
+    seconds = minutes * 60
+
+    command = "SCHEDULE_HOST_DOWNTIME;%(host)s;%(now)d;%(end)d;1;0;%(duration)d;fabric;fabric" % {
+        'now': timestamp,
+        'host': host,
+        'end': timestamp + seconds,
+        'duration': seconds
+    }
+    comment = "ADD_HOST_COMMENT;%(host)s;0;%(user)s;downtime scheduled by %(user)s via fabric" % {
+        'host': host,
+        'user': env.user
+    }
+    submit_nagios_cmd(command)
+    submit_nagios_cmd(comment)


### PR DESCRIPTION
Adds the ability to schedule downtime for a host in nagios. You call it
like this:

```
fab staging nagios.schedule_downtime:backend-3.backend.production,5
```

for 5 minutes of downtime on backend-3.backend.production.
