### PR TITLE
Make bodge unicorn more explicit

### DIFF
--- a/vm.py
+++ b/vm.py
@@ -36,7 +36,7 @@ def bodge_unicorn(name):
 
     Yes. This is a bodge. Sorry.
     """
-    pid = run("ps auxwww | grep '%s' | grep -F 'unicorn master' | grep -v grep | awk '{ print $2 }' | xargs" % name)
+    pid = run("ps auxwww | grep '/%s/' | grep -F 'unicorn master' | grep -v grep | awk '{ print $2 }' | xargs" % name)
     if pid:
         sudo("kill -9 %s" % pid)
     sudo("start '{0}' || restart '{0}'".format(name))


### PR DESCRIPTION
When running `vm.bodge_unicorn:frontend` the script would find both `datainsight-frontend` and `frontend`.

The included `grep` chain already finds things only by the directory name anyway, see example:

```
$ ps auxww | grep frontend | grep -F 'unicorn master'
deploy    1960  0.0  0.5  71280 20544 ?        Sl   11:46   0:00 unicorn master -D -P /var/run/frontend/app.pid -p 3005 -c /etc/govuk/unicorn.rb
deploy   21772  0.0  0.4  69068 16764 ?        Sl   Dec11   0:00 unicorn master -D -P /var/run/datainsight-frontend/app.pid -p 3027 -c /etc/govuk/unicorn.rb
```

To fix this I've anchored the grep in directory delimiters to ensure it only kills exactly the thing we want.
