### PR TITLE
Add a task to show the OS version

### DIFF
--- a/vm.py
+++ b/vm.py
@@ -16,6 +16,11 @@ def disk():
     run('df -kh')
 
 @task
+def os_version():
+    """Show operating system"""
+    run('facter lsbdistcodename lsbdistdescription operatingsystem operatingsystemrelease')
+
+@task
 def stopped_jobs():
     """Find stopped govuk application jobs"""
     with hide('running'):


### PR DESCRIPTION
Is `vm` the correct namespace for this? Is there a better way of getting this information?
