### PR TITLE
Add dist-upgrade task to apt.py

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -13,6 +13,7 @@ def upgrade():
 @task
 def dist_upgrade():
     """Perform non-interactive dist-upgrade using apt-get"""
+    prompt('dist-upgrade is a dangerous operation, can remove packages and generally break all the things. Are you sure you want to proceed? (y/n)', validate=r'^[Yy]$')
     sudo("apt-get -q update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" -yuq dist-upgrade")
 
 @task(default=True)


### PR DESCRIPTION
Adds a new Fabric task to perform `apt-get dist-upgrade` on the specified hosts, running `apt-get update` first. Runs non-interactively and prompts for confirmation before proceeding.

The command-line switches supplied to apt-get are as follows:
- `--force-confdef` and `--force-confold` instruct `dpkg` to choose the default action when faced with installing a new version of a configuration file rather than keeping the old version. If there is no
  default, in which case `dpkg` would usually prompt for a choice, prefer to keep the old version of the file.
- `-y` assumes yes to prompts such as whether to proceed with the upgrades.
- `-q` reduces the output and omits progress indicators.
- `-u` will print the list of packages to be upgraded, useful for logging or later verification.
