### PR TITLE
add `ntpq -p` output to ntp.status

### DIFF
--- a/ntp.py
+++ b/ntp.py
@@ -3,6 +3,7 @@ from fabric.api import *
 @task
 def status():
     """Report the VM's NTP status."""
+    run("ntpq -p")
     run("/usr/lib/nagios/plugins/check_ntp_time -q -H ntp.ubuntu.com -w 2 -c 3", warn_only=True)
 
 @task


### PR DESCRIPTION
Gives a bit more detail in the output about which specific peers exist, which ones are trusted, what the estimated offset and jitter is, etc.
