### PR TITLE
Do the right thing when creating statsd counters

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -1,3 +1,4 @@
+import re
 from fabric.api import *
 
 
@@ -12,4 +13,6 @@ def create_counter(name):
 
     Read about carbon-aggregator counters before using this task:
     https://github.gds/pages/gds/opsmanual/2nd-line/nagios.html#nginx-5xx-rate-too-high-for-many-apps-boxes"""
+    # remove an initial stats. prefix if present
+    name = re.sub(r"^stats\.","",name)
     run("echo -n '%s:0|c' > /dev/udp/localhost/8125" % name)


### PR DESCRIPTION
You don't need to specify an initial "stats." prefix when creating
statsd counters, since statsd will do that for you. However, this means
that if you _do_ add such a prefix, you'll end up erroneously creating a
counter with the name "stats.stats.foo" instead.

This commit strips a leading "stats." prefix if one was specified, but
doesn't error if one wasn't.
