### PR TITLE
Add more detail to the output of ntp.status

### DIFF
--- a/ntp.py
+++ b/ntp.py
@@ -3,6 +3,7 @@ from fabric.api import *
 @task
 def status():
     """Report the VM's NTP status."""
+    run("ntpq -p")
     run("/usr/lib/nagios/plugins/check_ntp_time -q -H ntp.ubuntu.com -w 2 -c 3", warn_only=True)
 
 @task


### PR DESCRIPTION
The `ntpq -p` command lists information about upstream peers, and
whether ntpd considers them to be accurate timesources ("truechimers")
or not.
