### PR TITLE
Add environments for platform1

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -196,9 +196,19 @@ def help(name):
     puts(textwrap.dedent(task.__doc__).strip())
 
 @task
+def p1production():
+    """Select platform1 production environment"""
+    _set_gateway('p1production')
+
+@task
 def production():
     """Select production environment"""
     _set_gateway('production')
+
+@task
+def p1staging():
+    """Select platform1 staging environment"""
+    _set_gateway('p1staging')
 
 @task
 def staging():


### PR DESCRIPTION
Platform1 production and staging. The `all` selector/task will fail with the
following until hosts entries are fixed for asset-master and asset-slave in
Pivotal [#65086976]:

```
paramiko.ChannelException: Administratively prohibited
```
