### PR TITLE
Add nagios.loadhosts task

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ paramiko==1.10.1
 pycrypto==2.6
 wsgiref==0.1.2
 jinja2==2.7.1
+requests==2.2.1


### PR DESCRIPTION
Add the ability to load a host list based on service status in Icinga.
Prompts for the URL because it can't be safely passed using CLI arguments.
Also prompts for confirmation of the loaded hosts, for safety.

Example usage to fix all NTP alerts (in a new environment only!):

```
(fabric)➜  fabric-scripts git:(master) ✗ fab p1production nagios.loadhosts ntp.resync
Icinga URL (jsonformat): https://nagios.p1production.alphagov.co.uk/cgi-bin/icinga/status.cgi?search_string=ntp+self-reported&limit=0&start=1&servicestatustypes=29&jsonoutput
```
