### PR TITLE
Require a reason when disabling Puppet

### DIFF
--- a/puppet.py
+++ b/puppet.py
@@ -9,9 +9,9 @@ def agent(*args):
     puppet(*args)
 
 @task
-def disable():
-    """Disable puppet runs"""
-    puppet('--disable')
+def disable(reason):
+    """Disable puppet runs. Requires a reason as a string arg"""
+    puppet('--disable "%s"' % reason)
 
 @task
 def enable():


### PR DESCRIPTION
So that we can keep track of why Puppet has been disabled on a host.

Example usage:

```
(fabric)➜  fabric-scripts git:(puppet_disable_reason) fab preview -H jumpbox-1.management puppet.disable:'dcarley testing'
[jumpbox-1.management] Executing task 'preview'
[jumpbox-1.management] Executing task 'puppet.disable'
[jumpbox-1.management] sudo: govuk_puppet --disable "dcarley testing"
```

Example output:

```
(fabric)➜  fabric-scripts git:(puppet_disable_reason) fab preview -H jumpbox-1.management puppet:'-v'
[jumpbox-1.management] Executing task 'preview'
[jumpbox-1.management] Executing task 'puppet'
[jumpbox-1.management] sudo: govuk_puppet -v
[jumpbox-1.management] out: Notice: Skipping run of Puppet configuration client; administratively disabled (Reason: 'dcarley testing');
[jumpbox-1.management] out: Use 'puppet agent --enable' to re-enable.
…
```
