### PR TITLE
Use `alert.cluster` when scheduling downtime

### DIFF
--- a/nagios.py
+++ b/nagios.py
@@ -27,7 +27,7 @@ def _nagios_hostname(host):
 
 
 @task
-@hosts(['monitoring.management'])
+@hosts(['alert.cluster'])
 def schedule_downtime(host,minutes='20'):
     """Schedules downtime for a host in nagios; default for 20 minutes"""
 


### PR DESCRIPTION
Use `alert.cluster` rather than `monitoring.management` when scheduling
downtime.

`monitoring.management` was renamed to `monitoring-1.management` in
fc9733. As of eb7284f, we have a `alert.cluster` which is aimed at
addressing one machine within a future group of monitoring boxes.
