### PR TITLE
Make ntp.status run both nagios check commands.

### DIFF
--- a/ntp.py
+++ b/ntp.py
@@ -5,6 +5,7 @@ def status():
     """Report the VM's NTP status."""
     run("ntpq -p")
     run("/usr/lib/nagios/plugins/check_ntp_time -q -H ntp.ubuntu.com -w 2 -c 3", warn_only=True)
+    run("/usr/lib/nagios/plugins/check_ntp_peer -H 127.0.0.1 -w 0.5 -c 1 -m @1 -n @0", warn_only=True)
 
 @task
 def resync():


### PR DESCRIPTION
To help with diagnosing "ntp self-reported failure" errors as well as drift.
