### PR TITLE
Revert "Add environments for platform1"

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -196,19 +196,9 @@ def help(name):
     puts(textwrap.dedent(task.__doc__).strip())
 
 @task
-def p1production():
-    """Select platform1 production environment"""
-    _set_gateway('p1production')
-
-@task
 def production():
     """Select production environment"""
     _set_gateway('production')
-
-@task
-def p1staging():
-    """Select platform1 staging environment"""
-    _set_gateway('p1staging')
 
 @task
 def staging():


### PR DESCRIPTION
This reverts commit 395916ce6e3668a30567321dc39f7b076d92bcd8.

We no longer need these now that DNS has changed to Platform1.
