### PR TITLE
Test package reboot file exists before outputting

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -35,7 +35,8 @@ def unattended_upgrade_dry_run():
 @task(default=True)
 def packages_with_reboots(*args):
     """Find out the packages that require a reboot"""
-    sudo('cat /var/run/reboot-required.pkgs')
+    package_reboot_file = '/var/run/reboot-required.pkgs'
+    sudo('if [ -f {0} ]; then cat {0}; else echo No packages with reboots; fi'.format(package_reboot_file))
 
 @task
 def reset_reboot_needed(*args):


### PR DESCRIPTION
This allows you to run the apt.packages_with_reboots task across
a wider array of machines, including those where there might not
be any packages that require a reboot.
