### PR TITLE
Upgrade Fabric to 1.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Fabric==1.6.0
+Fabric==1.8.3
 paramiko==1.10.1
 pycrypto==2.6
 wsgiref==0.1.2


### PR DESCRIPTION
So that we can use parallel execution with `env.gateway` again. It was
hanging previously, but now:

```
(fabric)➜  fabric-scripts git:(upgrade_fabric_183) ✗ fab -P staging class:elasticsearch do:date
[elasticsearch-1.backend] Executing task 'do'
[elasticsearch-2.backend] Executing task 'do'
[elasticsearch-3.backend] Executing task 'do'
[elasticsearch-3.backend] run: date
[elasticsearch-2.backend] run: date
[elasticsearch-1.backend] run: date
[elasticsearch-1.backend] out: Wed May 14 12:54:22 UTC 2014
[elasticsearch-1.backend] out:

[elasticsearch-3.backend] out: Wed May 14 12:54:22 UTC 2014
[elasticsearch-3.backend] out:

[elasticsearch-2.backend] out: Wed May 14 12:54:22 UTC 2014
[elasticsearch-2.backend] out:
```

I can't see any backwards incompatible changes in the intermediate releases:

```
https://fabric.readthedocs.org/en/1.8/changelog.html
```

This will come in useful for the Elasticsearch upgrade where we want all three
machines to run Puppet and come back ASAP.

/cc @rboulton @alphagov/team-infrastructure-admins 
