### PR TITLE
Add a task to purge from Fastly

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -1,0 +1,10 @@
+from fabric.api import *
+import cache
+
+@task
+@runs_once
+@roles('class-cache')
+def fastly_purge(*args):
+    "Purge items from Fastly, eg \"/one,/two,/three\""
+    for path in args:
+        run("curl -s -X PURGE -H 'Host: www.gov.uk' http://www-gov-uk.map.fastly.net%s" % path.strip())

--- a/fabfile.py
+++ b/fabfile.py
@@ -16,6 +16,7 @@ import app
 import apt
 import cache
 import campaigns
+import cdn
 import es
 import incident
 import licensify


### PR DESCRIPTION
This can be used as:

```
fab production cdn.fastly_purge:'/one,/two,/three'
```

It could also be used following a cache purge:

```
fab production cache.purge:'/one' cdn.fastly_purge:'/one'
```

This [Fixes #69166246]

Once this is merged, I will update the opsmanual
