### PR TITLE
Fix up Carrenza and Preview gateways

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -182,10 +182,7 @@ def _set_gateway(name):
     setting and makes sure that the correct known_hosts file will be consulted,
     then dynamically fetches a list of hosts from the gateway box.
     """
-    if name == 'preview_carrenza':
-        env.gateway = 'jumpbox.provider1.preview.govuk.service.gov.uk'
-    else:
-        env.gateway = 'jumpbox.{0}.alphagov.co.uk'.format(name)
+    env.gateway = 'jumpbox.{0}.alphagov.co.uk'.format(name)
     env.system_known_hosts = _fetch_known_hosts()
     env.roledefs.fetch()
 
@@ -213,11 +210,6 @@ def staging():
 def preview():
     """Select preview environment"""
     _set_gateway('preview')
-
-@task
-def preview_carrenza():
-    """Select preview environment"""
-    _set_gateway('preview_carrenza')
 
 @task
 def all():


### PR DESCRIPTION
Previously, we had a Preview gateway for accessing Carrenza with a separate
task to allow us to run Fabric commands against it. This commit removes
that, switching back to Preview, as DNS records have been updated for this
prior to the commit.
