### PR TITLE
[#43121095] Add puppet.loadhosts task

### DIFF
--- a/puppet.py
+++ b/puppet.py
@@ -1,5 +1,13 @@
 from fabric.api import *
 
+@task
+def loadhosts(*classnames):
+    """Load hosts that include given Puppet class(es)"""
+    classnames = ','.join(classnames)
+    with hide('running', 'stdout'):
+          with settings(host_string=env.gateway, gateway=None):
+              env.hosts = run('govuk_node_list -C %s' % classnames).splitlines()
+
 def puppet(*args):
     sudo('govuk_puppet %s' % ' '.join(args))
 


### PR DESCRIPTION
Loads hosts that use given Puppet class(es). This differs from the `class` task
which only returns nodes of a given "role". It uses the functionality added
to `govuk_node_list` in:

https://github.gds/gds/puppet/commit/d986313df235af0ac225f8e7f3e5838574a3dec0

For example, to run a command on machines that include the `redis` and
`govuk::apps::govuk_crawler_worker` hosts. Note there is `logs-redis-N` in
addition to `redis-N`:

```
(fabric)➜  fabric-scripts git:(puppet_loadhosts_by_classes) fab --hide=running,status preview puppet.loadhosts:redis,govuk::apps::govuk_crawler_worker hosts
logs-redis-1.management.production
logs-redis-2.management.production
mirrorer-1.management.production
redis-1.backend.production
redis-2.backend.production
```
