### PR TITLE
Include the assets hostname when purging from the CDN

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -1,11 +1,12 @@
 from fabric.api import *
-import cache
 
 @task
 @runs_once
 @roles('class-cache')
 def fastly_purge(*args):
     "Purge items from Fastly, eg \"/one,/two,/three\""
-    for path in args:
-        run("curl -s -X PURGE -H 'Host: www.gov.uk' http://www-gov-uk.map.fastly.net%s" % path.strip())
-        run("curl -s -X PURGE -H 'Host: assets.digital.cabinet-office.gov.uk' http://www-gov-uk.map.fastly.net%s" % path.strip())
+    govuk_fastly = 'http://www-gov-uk.map.fastly.net'
+    hostnames_to_purge = ['www.gov.uk', 'assets.digital.cabinet-office.gov.uk']
+    for govuk_path in args:
+        for hostname in hostnames_to_purge:
+            run("curl -s -X PURGE -H 'Host: {0}' {1}{2}".format(hostname, govuk_fastly, govuk_path.strip()))


### PR DESCRIPTION
Purge both the www.gov.uk domain and the assets domain from the CDN at the same time.
