### PR TITLE
Add nginx.gracefulrestart

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -10,6 +10,12 @@ def gracefulstop(wait=True):
         run('while pgrep nginx >/dev/null; do echo "Waiting for Nginx to exit.."; sleep 1; done')
 
 @task
+def gracefulrestart():
+    """Gracefully shutdown and start Nginx (not reload)"""
+    gracefulstop()
+    start()
+
+@task
 def disable_vhost(vhost_filename):
     """Disable a vhost by removing its symlink from /etc/nginx/sites-enabled"""
     sudo('rm -f /etc/nginx/sites-enabled/%s' % vhost_filename)


### PR DESCRIPTION
This calls `nginx.gracefulstop` (which blocks until Nginx has finished
in-flight requests) and then calls `nginx.start` before moving onto the next
host.

I need this to rollout some Nginx config changes that aren't picked up by a
graceful reload (HUP). It can also be used to pick up OpenSSL lib upgrades.
