### PR TITLE
Clean mongo.step_down_primary output

### DIFF
--- a/mongo.py
+++ b/mongo.py
@@ -16,19 +16,10 @@ def strip_dates(raw_output):
 def mongo_command(command):
     return "mongo --quiet --eval 'printjson(%s)'" % command
 
-def run_mongo_command(command, command_warn_only=False):
-    if command_warn_only:
-        with settings(warn_only=True):
-            response = run(mongo_command(command))
-    else:
-        response = run(mongo_command(command))
+def run_mongo_command(command):
+    response = run(mongo_command(command))
 
-    if response.return_code == 252:
-        dict_response = {"return_code": 252}
-    else:
-        dict_response = json.loads(strip_dates(response))
-
-    return dict_response
+    return json.loads(strip_dates(response))
 
 @task(default=True)
 @roles('class-mongo')


### PR DESCRIPTION
This cleans up the output of mongo.step_down_primary, and tidies up the code in mongo.py more generally.

Tested on staging (trimmed output):

```
$ fab staging -H mongo-3.backend mongo.step_down_primary
[mongo-3.backend] Executing task 'staging'
[mongo-3.backend] Executing task 'mongo.step_down_primary'
[mongo-3.backend] run: mongo --quiet --eval 'printjson(rs.stepDown(100))'

Done.
$ fab staging -H mongo-1.backend mongo.find_primary
[mongo-1.backend] Executing task 'staging'
[mongo-1.backend] Executing task 'mongo.find_primary'
[mongo-1.backend] run: mongo --quiet --eval 'printjson(rs.isMaster())'
Current primary is backend-2.mongo:27017
```
