### PR TITLE
Remove unused kernels

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -19,6 +19,7 @@ import campaigns
 import cdn
 import es
 import incident
+import kernel
 import licensify
 import logstream
 import mongo

--- a/kernel.py
+++ b/kernel.py
@@ -1,0 +1,11 @@
+from fabric.api import *
+
+@task
+def show_unused():
+    """Show unused kernels using govuk_unused_kernels"""
+    run('govuk_unused_kernels')
+
+@task
+def remove_unused():
+    """Remove unused kernels"""
+    sudo('govuk_unused_kernels | xargs apt-get purge -y')


### PR DESCRIPTION
Based on the output of `govuk_unused_kernels`, allow Fabric to support the
removal of unused kernels which often take up a lot of disc space.
