### PR TITLE
Only reboot a vm if necessary

### DIFF
--- a/vm.py
+++ b/vm.py
@@ -57,13 +57,20 @@ def reload_unicorn(name):
 
 @task
 def reboot():
-  """Schedule a host for downtime in nagios and reboot
+  """Schedule a host for downtime in nagios and reboot (if required)
 
   Usage:
   fab production -H frontend-1.frontend.production vm.reboot
   """
   from nagios import schedule_downtime
-  execute(schedule_downtime, env['host_string'])
+  result = run("/usr/local/bin/check_reboot_required 30 0", warn_only=True)
+  if (not result.succeeded):      
+      execute(schedule_downtime, env['host_string'])
+      execute(force_reboot)
+
+@task
+def force_reboot():
+  """Schedule a host for downtime in nagios and force reboot (even if not required)"""
   run("sudo shutdown -r now")
 
 @task


### PR DESCRIPTION
I'd like to get to a point where we can run a command such as:

```
fab staging puppet_class:govuk::safe_to_reboot::yes numbered:1 vm.reboot
```

This commit makes such a command more palatable by only rebooting the
machines which actually have outstanding packages which require it.

For those occasions where you want to reboot regardless of packages,
I've added vm.force_reboot to allow you to do that.
