### PR TITLE
Fix rebooting issue

### DIFF
--- a/vm.py
+++ b/vm.py
@@ -66,7 +66,9 @@ def reboot():
   result = run("/usr/local/bin/check_reboot_required 30 0", warn_only=True)
   if (not result.succeeded):      
       execute(schedule_downtime, env['host_string'])
-      execute(force_reboot)
+      # we need to ensure we only execute this task on the current
+      # host we're operating on, not every host in env.hosts
+      execute(force_reboot, hosts=[env['host_string']])
 
 @task
 def force_reboot():


### PR DESCRIPTION
There was an issue where if any one host had packages requiring a
reboot, it would cause fabric to run force_reboot on every host in
env.hosts -- ie if any host needed rebooting, they would all get
rebooted.

This fixes the issue by ensuring that when we execute force_reboot, we
ensure we're only doing so for the current host.
