### PR TITLE
Parallelise kernel maintenance jobs

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -1,11 +1,13 @@
 from fabric.api import *
 
 @task
+@parallel(pool_size=10)
 def show_unused():
     """Show unused kernels using govuk_unused_kernels"""
     run('govuk_unused_kernels')
 
 @task
+@parallel(pool_size=10)
 def remove_unused():
     """Remove unused kernels"""
     sudo('govuk_unused_kernels | xargs apt-get purge -y')


### PR DESCRIPTION
This job takes quite a while, and will get longer as the number of machines
we use grows in time. To try and speed it up, but also retain some sanity,
add some paralellisation.

As there are a large number of hosts, let's not overwhelm local machine by
running too many concurrent Fabric processes in separate threads. Do this by
using a moving bubble as a kwarg to limit Fabric to a set number of
concurrently active processes.

We could have specified this globally, but doing it this way requires no
prior knowledge of this caveat.
