### PR TITLE
Add a safe redis reboot task

### DIFF
--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -30,3 +30,13 @@ def safe_reboot():
     if (health['status'] != 'green'):
         abort("Cluster health is %s, won't reboot" % health['status'])
     execute(vm.reboot, hosts=[env['host_string']])
+
+
+@task
+@serial
+@runs_once
+def redis_safe_reboot():
+    """Reboot only if no logs in queue"""
+    log_length = run('redis-cli llen logs')
+    if log_length == '(integer) 0':
+        execute(vm.reboot, hosts=[env['host_string']])


### PR DESCRIPTION
Will only reboot redis if there are not logs in the log queue
