### PR TITLE
Icinga downtime for services as well as hosts

### DIFF
--- a/nagios.py
+++ b/nagios.py
@@ -38,7 +38,7 @@ def schedule_downtime(host,minutes='20'):
 
     host = _nagios_hostname(host)
 
-    command = "SCHEDULE_HOST_DOWNTIME;%(host)s;%(now)d;%(end)d;1;0;%(duration)d;fabric;fabric" % {
+    command = "SCHEDULE_HOST_SVC_DOWNTIME;%(host)s;%(now)d;%(end)d;1;0;%(duration)d;fabric;fabric" % {
         'now': timestamp,
         'host': host,
         'end': timestamp + seconds,


### PR DESCRIPTION
Make sure that all services associated with a host are also scheduled for
downtime. Otherwise Blinken gets fill with alerts for the services when you
reboot a machine. There's not an easy way to propagate the comment from the
host, but I think it should be clear enough as it is.
