### PR TITLE
FOR DISCUSSION: Remove assets host from hostname array

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -6,7 +6,7 @@ from fabric.api import *
 def fastly_purge(*args):
     "Purge items from Fastly, eg \"/one,/two,/three\""
     govuk_fastly = 'http://www-gov-uk.map.fastly.net'
-    hostnames_to_purge = ['www.gov.uk', 'assets.digital.cabinet-office.gov.uk']
+    hostnames_to_purge = ['www.gov.uk']
     for govuk_path in args:
         for hostname in hostnames_to_purge:
             run("curl -s -X PURGE -H 'Host: {0}' {1}{2}".format(hostname, govuk_fastly, govuk_path.strip()))


### PR DESCRIPTION
Assets are now fronted by CloudFlare, who don't use the same HTTP method to 
allow purging. Fastly expect the PURGE method whereas CloudFlare expect the 
DELETE method (see [this section](https://www.cloudflare.com/docs/next/#zone-purge-individual-files) of the API documentation).

Purging individual content from CloudFlare will require a bit more of a
think, as there are some fundamental changes regarding authorisation that
we don't need to consider in the Fastly purge implementation, namely:
- Zone ID is required in the endpoint
- Email and API key need to be sent as X-Auth-Email and X-Auth-Key headers
  respectively

These details aren't available to everyone, so we need to either sort user
permissions out (something like the shared account with limited permission sets
we have for Fastly deployment would work), or work it in to Jenkins in a way that the
email and API key aren't exposed to those who don't need access to them.
