### PR TITLE
Add tasks to stop and start an app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,23 @@
 from fabric.api import *
 
+
 @task
 def restart(app):
     """Restart a particular app"""
-    sudo("service %s restart" % app)
+    _service(app, 'restart')
+
+
+@task
+def stop(app):
+    """Stop a particular app"""
+    _service(app, 'stop')
+
+
+@task
+def start(app):
+    """Start a particular app"""
+    _service(app, 'start')
+
+
+def _service(app, command):
+    sudo('service {} {}'.format(app, command))


### PR DESCRIPTION
These convenience tasks around stopping and starting a service have been
added to make the documentation of what to do in the event of a security
incident a bit simpler. The steps an oncall person would have to follow
are all single argument fabric tasks.
