### PR TITLE
Add tasks for deduping stats announcements

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -34,6 +34,7 @@ import rkhunter
 import search
 import statsd
 import vm
+import whitehall
 
 HERE = os.path.dirname(__file__)
 SSH_DIR = os.path.join(HERE, '.ssh')

--- a/whitehall.py
+++ b/whitehall.py
@@ -1,0 +1,21 @@
+from fabric.api import task, hosts, sudo, cd, execute
+
+
+@task
+def dedupe_stats_announcement_from_file(filename):
+    """De-duplicate Whitehall statistics accouncements from a CSV file"""
+    with open(filename) as fd:
+        duplicates = [line.strip().split(',') for line in fd]
+        for duplicate_slug, authoritative_slug in duplicates:
+            execute(
+                dedupe_stats_announcement, duplicate_slug, authoritative_slug)
+
+
+@task
+@hosts('whitehall-backend-1.backend')
+def dedupe_stats_announcement(duplicate_slug, authoritative_slug):
+    """De-duplicate Whitehall statistics announcement"""
+    command = 'govuk_setenv whitehall ./script/dedupe_stats_announcement {} {}'
+    with cd('/var/apps/whitehall'):
+        sudo(command.format(duplicate_slug, authoritative_slug),
+             user='deploy')


### PR DESCRIPTION
This adds a couple of fabric tasks around the [de-duping whitehall stats
announcements](https://github.gds/pages/gds/opsmanual/2nd-line/applications/whitehall.html#de-duplicating-whitehall-statistics-announcements) process. It makes me nervous that we have a common task that involves us SSHing onto a production machine and manually running a specific command as a
specific user from a specific location. This just wraps a little bit of that up.

I'm undecided as to whether this is a good idea, there is a noise cost to adding fabric tasks. It feels like this should be a web interface to do this in the publishing tools rather than a fabric script.
