### PR TITLE
Add commands to handle Whitehall scheduled pubs

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,3 +21,17 @@ def start(app):
 
 def _service(app, command):
     sudo('service {} {}'.format(app, command))
+
+@task
+@runs_once
+@roles('class-whitehall_backend')
+def overdue_scheduled_publications():
+    with cd('/var/apps/whitehall'):
+        sudo('govuk_setenv whitehall bundle exec rake publishing:overdue:list', user='deploy')
+
+@task
+@runs_once
+@roles('class-whitehall_backend')
+def schedule_publications():
+    with cd('/var/apps/whitehall'):
+        sudo('govuk_setenv whitehall bundle exec rake publishing:overdue:publish', user='deploy')


### PR DESCRIPTION
Add `app.overdue_scheduled_publications` and `app.schedule_publications`. These replace the long manual commands that require SSH in the Opsmanual.
