### PR TITLE
Add `cdn.purge_all` to completely purge URLs

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -1,5 +1,7 @@
 from fabric.api import *
 
+from cache import purge as cache_purge
+
 @task
 @runs_once
 @roles('class-cache')
@@ -10,3 +12,11 @@ def fastly_purge(*args):
     for govuk_path in args:
         for hostname in hostnames_to_purge:
             run("curl -s -X PURGE -H 'Host: {0}' {1}{2}".format(hostname, govuk_fastly, govuk_path.strip()))
+
+@task
+@runs_once
+@roles('class-cache')
+def purge_all(*args):
+    "Purge items from Fastly and cache machines, eg \"/one,/two,/three\""
+    cache_purge(*args)
+    fastly_purge(*args)


### PR DESCRIPTION
This command purges paths from both our local Varnish cache and (currently) from Fastly.

Use this command to absolutely guarantee dropping a path from cache.
