### PR TITLE
Add `app.rolling_stop_start` task

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from fabric.api import *
-
+from fabric.decorators import serial
 
 @task
 def restart(app):
@@ -18,6 +18,14 @@ def start(app):
     """Start a particular app"""
     _service(app, 'start')
 
+
+@task
+@serial
+@with_settings(warn_only=False)
+def rolling_stop_start(app):
+    """Perform a sequential forced reload of an app that stops at first failure"""
+    stop(app)
+    start(app)
 
 def _service(app, command):
     sudo('service {} {}'.format(app, command))


### PR DESCRIPTION
This is a task which forcibly executes in serial mode only and stops/starts a named app. It will exit on the first failure to execute instead of warning.

One thing I couldn't figure out is the right command to get the script to block until the server is running - given the way we use Unicorn herder and parent processes I'm not sure this is even possible.
