### PR TITLE
Tweaks to Elasticsearch tasks

### DIFF
--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -22,6 +22,11 @@ def cluster_health():
     return run("curl -XGET 'http://localhost:9200/_cluster/health?pretty'")
 
 @task
+def cluster_nodes():
+    """Get cluster nodes"""
+    return run("curl -XGET 'http://localhost:9200/_cluster/nodes?pretty'")
+
+@task
 @serial
 @runs_once
 def safe_reboot():


### PR DESCRIPTION
#### Fix description of elasticsearch.cluster_health

Looks like this was copy/pasta from the task above it.
#### Pretty format Elasticsearch cluster_health output

So that the JSON output is more human readable.
#### Add elasticsearch.cluster_nodes task

This is good for diagnosing split brain where each node has a different view
of the cluster.

I'd like to replace a lot of the instructions in the opsmanual that
reference the head plugin with these commands, because they're safer.
