### PR TITLE
[#74851568] Task to delete stale Whisper files

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -19,6 +19,7 @@ import cache
 import campaigns
 import cdn
 import elasticsearch
+import graphite
 import incident
 import kernel
 import licensify

--- a/graphite.py
+++ b/graphite.py
@@ -1,0 +1,8 @@
+from fabric.api import *
+
+@task
+@hosts('graphite-1.management')
+def prune_stale_whisper_files():
+    """Delete Whisper files that have not been modified in over 90 days"""
+    sudo("find /opt/graphite/storage/whisper -type f -mtime +90 -exec rm {} +")
+    sudo("find /opt/graphite/storage/whisper -type d -empty -exec rmdir {} +")


### PR DESCRIPTION
Add a task to delete stale [Whisper](https://github.com/graphite-project/whisper) files, as used by [Graphite](https://github.com/graphite-project/graphite-web).

The task will delete Whisper files that have not been modified in over
90 days, then remove any empty directories left as a result.

The rationale behind this is that if a metric has not been updated in 90
days, it is likely an artefact of historical configuration and is no
longer used.

Under certain circumstances, a current and valid metric may not be
updated in a long time, for example a metric tracking HTTP 500 errors
may not update if no error has occurred over the period in question.
This is unusual however, and it's unlikely that we draw enough value
from those metrics to be concerned about deleting them.

Note that `find(1)` uses the `-type` argument to target files only; the
modification times for directories do not change when the files they
contain are modified.

Also, uses `rmdir(1)`, which will refuse to delete a non-empty
directory.
