### PR TITLE
Fix Puppet task to check whether agent is disabled

### DIFF
--- a/puppet.py
+++ b/puppet.py
@@ -30,7 +30,7 @@ def check_disabled():
     lockfile = '/var/lib/puppet/state/agent_disabled.lock'
 
     with hide('running'):
-        run('test -f {0} && echo DISABLED || echo ENABLED'.format(lockfile))
+        sudo('test -f {0} && echo DISABLED || echo ENABLED'.format(lockfile))
 
 @task
 def dryrun(*args):


### PR DESCRIPTION
The lockfile is owned by root, so if you don't run this command with sudo it will always output "ENABLED".