### PR TITLE
Use whitehall_backend class when reindexing search

### DIFF
--- a/search.py
+++ b/search.py
@@ -13,7 +13,7 @@ SEARCHABLE_APPS = {
     'smartanswers':          ('frontend', ['panopticon:register']),
     'tariff':                ('frontend', ['panopticon:register']),
     'travel-advice-publisher':('backend', ['panopticon:register', 'panopticon:reregister_editions']),
-    'whitehall':             ('backend',  ['rummager:index']),
+    'whitehall':             ('whitehall_backend',  ['rummager:index']),
 }
 
 @task


### PR DESCRIPTION
The Whitehall application now has its own backend servers. When
reindexing search, use the `whitehall_backend` class of machines.