### PR TITLE
Add a command to reload an app gracefully

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,18 @@ def restart(app):
 
 
 @task
+def reload(app):
+    """Reload a particular app.
+
+    Unlike `restart`, this will tell the app to reload itself gracefully; for
+    apps running under unicornherder, this will spin up a new process, then
+    stop the old one after a short overlap period.
+
+    """
+    _service(app, 'reload')
+
+
+@task
 def stop(app):
     """Stop a particular app"""
     _service(app, 'stop')


### PR DESCRIPTION
This gives us a way to reload an app that's misbehaving (for instance, by using up large chunks of memory) with less risk of requests getting dropped while we wait for the new app to start.