### PR TITLE
Fix puppet_class when using parallel mode

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -249,6 +249,7 @@ def klass(class_name):
     env.hosts.extend(env.roledefs['class-%s' % class_name]())
 
 @task
+@serial
 @hosts('localhost')
 def puppet_class(class_name):
     """Select all machines which include a given puppet class"""


### PR DESCRIPTION
Force this to serial so that it doesn't hang when using parallel mode:

    (fabric)➜  fabric-scripts git:(master) ✗ fab preview puppet_class:nginx hosts -P
    [localhost] Executing task 'puppet_class'
    No handlers could be found for logger "paramiko.transport"