### PR TITLE
Mongo replication

### DIFF
--- a/mongo.py
+++ b/mongo.py
@@ -10,6 +10,7 @@ import puppet
 
 today = date.today().strftime("%a %b %d")
 
+
 def node_name(node_name):
     return node_name.split('.production').pop(0)
 
@@ -86,7 +87,7 @@ def i_am_primary(primary=None):
     backend_re = re.compile(r'^backend-(\d+).mongo$')
     if primary == env['host_string']:
         return True
-    elif env['host_string'].split('.')[0] == primary.split('.')[0]: 
+    elif env['host_string'].split('.')[0] == primary.split('.')[0]:
         # lol licensify-mongo-n.licensify
         return True
     elif backend_re.match(primary):
@@ -166,8 +167,9 @@ def status():
 @task
 def step_down_primary(seconds='100'):
     """Step down as primary for a given number of seconds (default: 100)"""
-    # Mongo returns an exit code of 252 when the primary steps down, as well as disconnecting
-    # the current console session. We need to mark that as okay so that run() won't error.
+    # Mongo returns an exit code of 252 when the primary steps down, as well
+    # as disconnecting the current console session. We need to mark that as
+    # okay so that run() won't error.
     with hide('output'), settings(ok_ret_codes=[0, 252]):
         if i_am_primary():
             run_mongo_command("rs.stepDown(%s)" % seconds)

--- a/mongo.py
+++ b/mongo.py
@@ -1,6 +1,7 @@
-from fabric.api import *
+from fabric.api import task, roles, runs_once
+from fabric.api import run, sudo, hide, settings, abort, execute, puts, env
 from fabric import colors
-from datetime import *
+from datetime import date
 from time import sleep
 import json
 import re
@@ -10,17 +11,22 @@ today = date.today().strftime("%a %b %d")
 def node_name(node_name):
     return node_name.split('.production').pop(0)
 
+
+def node_health(health_code):
+    return "OK" if health_code == 1 else "ERROR"
+
+
 def strip_dates(raw_output):
     stripped_isodates = re.sub(r'ISODate\((.*?)\)', r'\1', raw_output)
     return re.sub(r'Timestamp\((.*?)\)', r'"\1"', stripped_isodates)
 
 
 def mongo_command(command):
-    return "mongo --quiet --eval 'printjson(%s)'" % command
+    return "mongo --quiet --eval '%s'" % command
 
 
 def run_mongo_command(command):
-    response = run(mongo_command(command))
+    response = run(mongo_command('printjson(%s)' % command))
 
     try:
         return json.loads(strip_dates(response))
@@ -79,14 +85,18 @@ def get_cluster_status():
         parsed_statuses = []
 
         for member_status in status['members']:
-            name = node_name(member_status['name'])
-            health = "OK" if member_status['health'] == 1 else "ERROR"
-            state = member_status['stateStr']
-            heartbeat = member_status.get('lastHeartbeat', '')
-            parsed_status = {'name': name,
-                             'health': health,
-                             'state': state,
-                             'heartbeat': heartbeat}
+            parsed_status = {
+                'name': node_name(member_status['name']),
+                'health': node_health(member_status['health']),
+                'state': member_status['stateStr'],
+            }
+            keys = [
+                'uptime', 'optime', 'optimeDate',
+                'lastHeartbeat', 'lastHeartbeatRecv',
+                'lastHeartbeatMessage',
+            ]
+            for key in keys:
+                parsed_status[key] = member_status.get(key, '')
             parsed_statuses.append(parsed_status)
 
         return parsed_statuses
@@ -104,17 +114,34 @@ def cluster_is_ok():
 
 
 @task
+@runs_once
+@roles('class-mongo')
 def status():
     """Check the status of the mongo cluster"""
-    
-    member_statuses = get_cluster_status()
-    format_string = "| {0:<22} | {1:<8} | {2:<10} | {3:<22} |"
-    print(format_string.format('Name', 'Health', 'State', 'Heartbeat'))
-    for status in member_statuses:
-        print(format_string.format(status['name'],
-                                   status['health'],
-                                   status['state'],
-                                   status['heartbeat']))
+    with hide('output'), settings(host_string=_find_primary()):
+        print(colors.blue(
+            "Primary replication info - db.printReplicationInfo()",
+            bold=True))
+        print(run(mongo_command("db.printReplicationInfo()")))
+
+        print(colors.blue(
+            "Slave replication info - db.printSlaveReplicationInfo()",
+            bold=True))
+        print(run(mongo_command("db.printSlaveReplicationInfo()")))
+
+        print(colors.blue(
+            "Replication status - rs.status()",
+            bold=True))
+        for status in get_cluster_status():
+            print(colors.cyan(
+                "{} - {}".format(status['name'], status['state'])))
+
+            keys = ['health', 'uptime', 'optime', 'optimeDate',
+                    'lastHeartbeat', 'lastHeartbeatRecv',
+                    'lastHeartbeatMessage']
+            for key in keys:
+                if status[key]:
+                    print("{0:<22} {1}".format(key, status[key]))
 
 
 @task


### PR DESCRIPTION
Improve the output of the `mongo.status` task by adding output from `db.printReplicationInfo()` and `db.printSlaveReplicationInfo()` and also adding extra fields from `rs.status()`. I have colourised the output so that it's easy to distinguish the output from different mongo commands and made it very clear which command the output is from.

This pull request also adds new task to force a mongo node to resync (`mongo.force_resync`). This encodes the process previously described in the opsmanual where mongodb is stopped, it's data is removed and then it is restarted again. This new task will refuse to be run on the primary.