### PR TITLE
Move whitehall tasks into whitehall module

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,17 +33,3 @@ def start(app):
 
 def _service(app, command):
     sudo('service {} {}'.format(app, command))
-
-@task
-@runs_once
-@roles('class-whitehall_backend')
-def overdue_scheduled_publications():
-    with cd('/var/apps/whitehall'):
-        sudo('govuk_setenv whitehall bundle exec rake publishing:overdue:list', user='deploy')
-
-@task
-@runs_once
-@roles('class-whitehall_backend')
-def schedule_publications():
-    with cd('/var/apps/whitehall'):
-        sudo('govuk_setenv whitehall bundle exec rake publishing:overdue:publish', user='deploy')


### PR DESCRIPTION
Move the whitehall tasks from the app module into the whitehall module
to allow for some refactoring. Remove duplication and simplify the tasks
a bit.