### PR TITLE
Make use of util module in whitehall module

### DIFF
--- a/util.py
+++ b/util.py
@@ -1,11 +1,14 @@
 import random
+import re
 
 from fabric.api import env, cd, sudo
+
 
 def use_random_host(role):
     """Use a randomly chosen host from the given role"""
     hosts = env.roledefs[role]()
     env.host_string = random.choice(hosts)
+
 
 def rake(app, task, *args, **params):
     """Run a rake task for the specified application
@@ -13,28 +16,55 @@ def rake(app, task, *args, **params):
     If given positional arguments, converts them to rake's square bracket
     syntax (ie, rake foo[arg1,arg2,...])
 
-    If given named arguments, converts them to environment variable syntax (ie,
-    rake foo key1=val1 key2=val2)
-
+    If given named arguments, converts them to environment variables (ie.
+    KEY1=val1 KEY2=val2 rake foo)
     """
-    with cd('/var/apps/%s' % app):
-        cmd = "govuk_setenv '%s' bundle exec rake '%s'" % (app, task)
+    if args:
+        _validate_strings("rake variable",
+                          args, bad_chars=",]'")
+        task = "{}[{}]".format(task, ','.join(args))
 
-        if args:
-            for arg in args:
-                if ',' in arg or ']' in arg or "'" in arg:
-                    raise RuntimeError("Can't pass arguments containing any of ,]' to rake")
-            cmd += "'[" + ','.join(args) + "]'"
+    bundle_exec(app, task, **params)
 
-        if params:
-            for key, value in params.items():
-                if '=' in key or "'" in key:
-                    raise RuntimeError("Can't have = or ' in rake environment keys")
-                if "'" in value:
-                    raise RuntimeError("Can't have ' in rake environment values")
-            cmd += ' ' + ' '.join(
-                "'%s=%s'" % (key, value)
-                for (key, value) in params.items()
-            )
 
-        sudo(cmd, user='deploy')
+def bundle_exec(app, cmd, **params):
+    """Run any command through bundle exec for the specified application
+
+    If given named arguments, converts them to environment variables (ie.
+    KEY1=val1 KEY2=val2 command)
+    """
+    command(app, "bundle exec {}".format(cmd), **params)
+
+
+def command(app, cmd, **params):
+    """Run any command for the specified application
+
+    If given named arguments, converts them to environment variables (ie.
+    KEY1=val1 KEY2=val2 command)
+    """
+    env_vars = ""
+    if params:
+        _validate_strings("environment variable name",
+                          params.keys(), pattern=r"^[A-Z_][A-Z_0-9]*$")
+        _validate_strings("environment variable value",
+                          params.values(), pattern=r"^[^']*$")
+        env_vars = ' '.join(
+            "{}='{}'".format(name, value)
+            for (name, value) in params.items()) + ' '
+
+    with cd('/var/apps/{}'.format(app)):
+        sudo("{}govuk_setenv '{}' {}".format(env_vars, app, cmd),
+             user='deploy')
+
+
+def _validate_strings(label, strings, pattern=None, bad_chars=None):
+    if pattern is not None:
+        pattern = re.compile(pattern)
+
+    for string in strings:
+        if pattern is not None and not pattern.match(string):
+            raise RuntimeError("Invalid {} '{}' must match {}".format(
+                label, string, pattern.pattern))
+        if bad_chars is not None and any(c in string for c in bad_chars):
+            raise RuntimeError("Invalid {} '{}' must not contain {}".format(
+                label, string, bad_chars))

--- a/whitehall.py
+++ b/whitehall.py
@@ -1,4 +1,5 @@
-from fabric.api import task, sudo, cd, execute, runs_once, roles
+from fabric.api import task, execute, runs_once, roles
+import util
 
 
 @task
@@ -20,7 +21,7 @@ def dedupe_stats_announcement(duplicate_slug, authoritative_slug, noop=False):
     command = './script/dedupe_stats_announcement{} {} {}'.format(
         option, duplicate_slug, authoritative_slug)
 
-    _run_whitehall_command(command)
+    util.bundle_exec('whitehall', command)
 
 
 @task
@@ -29,7 +30,7 @@ def dedupe_stats_announcement(duplicate_slug, authoritative_slug, noop=False):
 def unarchive_content(*edition_ids):
     """Unarchive Whitehall content"""
     for edition_id in edition_ids:
-        _run_whitehall_rake('unarchive_edition[{}]'.format(edition_id))
+        util.rake('whitehall', 'unarchive_editions', edition_id)
 
 
 @task
@@ -37,7 +38,7 @@ def unarchive_content(*edition_ids):
 @roles('class-whitehall_backend')
 def overdue_scheduled_publications():
     """List overdue scheduled publications"""
-    _run_whitehall_rake('publishing:overdue:list')
+    util.rake('whitehall', 'publishing:overdue:list')
 
 
 @task
@@ -45,7 +46,7 @@ def overdue_scheduled_publications():
 @roles('class-whitehall_backend')
 def schedule_publications():
     """Publish overdue scheduled publications"""
-    _run_whitehall_rake('publishing:overdue:publish')
+    util.rake('whitehall', 'publishing:overdue:publish')
 
 
 @task
@@ -54,15 +55,4 @@ def schedule_publications():
 def unpublish_statistics_announcement(*slugs):
     """Unpublish statistics announcements and register 410 GONE routes"""
     for slug in slugs:
-        _run_whitehall_rake(
-            'unpublish_statistics_announcement[{}]'.format(slug))
-
-
-def _run_whitehall_rake(task):
-    _run_whitehall_command('rake {}'.format(task))
-
-
-def _run_whitehall_command(command):
-    with cd('/var/apps/whitehall'):
-        sudo('govuk_setenv whitehall bundle exec {}'.format(command),
-             user='deploy')
+        util.rake('whitehall', 'unpublish_statistics_announcement', slug)


### PR DESCRIPTION
- Refactor the `rake` function to pull out `bundle_exec` and `command`
  functions that can be used for non-rake jobs.
- Make use of `rake` and `bundle_exec` in the `whitehall` module.

This change also changes the rules around what a valid environment
variable name should be. Based on shell support [1] I have decided to go
with upercase letters, digits and underscores and not starting with a
digit.

[1]
http://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names/2821183#2821183