### PR TITLE
Don't import other fab tasks into mongo.py

### DIFF
--- a/mongo.py
+++ b/mongo.py
@@ -5,8 +5,6 @@ from datetime import date
 from time import sleep
 import json
 import re
-import app
-import puppet
 
 today = date.today().strftime("%a %b %d")
 
@@ -50,15 +48,15 @@ def force_resync():
     if i_am_primary():
         abort(colors.red("Refusing to force resync on primary", bold=True))
 
-    execute(puppet.disable, "Forcing mongodb resync")
-    execute(app.stop, "mongodb")
+    execute("puppet.disable", "Forcing mongodb resync")
+    execute("app.stop", "mongodb")
     # wait for mongod process to stop
     while run("ps -C mongod", quiet=True).return_code == 0:
         puts("Waiting for mongod to stop")
         sleep(1)
     sudo("rm -rf /var/lib/mongodb/*")
-    execute(app.start, "mongodb")
-    execute(puppet.enable)
+    execute("app.start", "mongodb")
+    execute("puppet.enable")
 
 
 def _find_primary():


### PR DESCRIPTION
Importing other tasks causes all of the puppet tasks to be named `mongo.puppet`, `mongo.puppet.agent`, etc.

Passing a string containing the task name to execute runs the fab task without requiring an import.