### PR TITLE
Remove roles tag from mongo.status task

### DIFF
--- a/mongo.py
+++ b/mongo.py
@@ -133,7 +133,6 @@ def cluster_is_ok():
 
 @task
 @runs_once
-@roles('class-mongo')
 def status():
     """Check the status of the mongo cluster"""
     with hide('output'), settings(host_string=_find_primary()):


### PR DESCRIPTION
The four mongo boxes are all in different classes, and this causes the task to only look at the mongo-?.backend boxes.