### PR TITLE
Fix util.rake and whitehall.unarchive_content

### DIFF
--- a/util.py
+++ b/util.py
@@ -24,7 +24,7 @@ def rake(app, task, *args, **params):
                           args, bad_chars=",]'")
         task = "{}[{}]".format(task, ','.join(args))
 
-    bundle_exec(app, task, **params)
+    bundle_exec(app, "rake " + task, **params)
 
 
 def bundle_exec(app, cmd, **params):

--- a/whitehall.py
+++ b/whitehall.py
@@ -30,7 +30,7 @@ def dedupe_stats_announcement(duplicate_slug, authoritative_slug, noop=False):
 def unarchive_content(*edition_ids):
     """Unarchive Whitehall content"""
     for edition_id in edition_ids:
-        util.rake('whitehall', 'unarchive_editions', edition_id)
+        util.rake('whitehall', 'unarchive_edition', edition_id)
 
 
 @task


### PR DESCRIPTION
util.rake was just running "bundle exec {command}" instead of "bundle
exec rake {command}".

Also, the rake task that unarchive_content needs to run is
`unarchive_edition`, rather than `unarchive_editions`.

On the plus side, after these changes were made, this all worked
wonderfully.