### PR TITLE
Add a rabbitmq.safe_reboot command

### DIFF
--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -1,7 +1,67 @@
 from fabric.api import *
+from time import sleep
+import re
 
 @task
 @roles('class-rabbitmq')
 def status():
     """Output the RabbitMQ cluster status"""
     sudo('rabbitmqctl cluster_status', warn_only=True)
+
+
+def cluster_is_ok():
+    """Check if the cluster is okay.
+
+    Returns True if so.  Prints a message and returns False if not.
+
+    """
+    with hide('everything'):
+        status = sudo('rabbitmqctl cluster_status')
+    # Expected status is something like:
+    #
+    # [{nodes,[{disc,['rabbit@rabbitmq-1','rabbit@rabbitmq-2',
+    #                 'rabbit@rabbitmq-3']}]},
+    # {running_nodes,['rabbit@rabbitmq-2','rabbit@rabbitmq-3','rabbit@rabbitmq-1']},
+    # {cluster_name,<<"rabbit@rabbitmq-1.backend.production">>},
+    # {partitions,[]}]
+    #
+    # We need to ensure that partitions is empty, and the list of running nodes
+    # is the same as the list of known nodes.
+
+    status = re.sub(r'\s', '', status) 
+    known_nodes = re.search(r'\{nodes,\[\{disc,\[([^]]+)\]', status)
+    running_nodes = re.search(r'\{running_nodes,\[([^]]+)\]', status)
+    partitions = re.search(r'\{partitions,\[([^]]*)\]', status)
+
+    if not known_nodes or not running_nodes or not partitions:
+        print("Couldn't parse status output: %r" % status)
+        return False
+
+    known_nodes = ','.join(sorted(known_nodes.group(1).split(',')))
+    running_nodes = ','.join(sorted(running_nodes.group(1).split(',')))
+    partitions = partitions.group(1)
+
+    if known_nodes != running_nodes:
+        print("Known nodes differ from running nodes: %r and %r" %
+              (known_nodes, running_nodes))
+        return False
+
+    if partitions:
+        print("Cluster currently has a partition: %r" % partitions)
+        return False
+
+    return True
+
+
+@task
+@roles('class-rabbitmq')
+def safe_reboot():
+    """Reboot rabbitmq machines, waiting for cluster to be healthy first"""
+    import vm
+    while True:
+        if cluster_is_ok():
+            break
+        print("Waiting for cluster to be okay")
+        sleep(5)
+
+    execute(vm.reboot, hosts=[env['host_string']])


### PR DESCRIPTION
This reboots all nodes in the cluster one-by-one (if they need rebooting), waiting for the
cluster status to be good before rebooting each.

The cluster status check checks that all known nodes are running, and
that there are no partitions.

I've used this successfully to reboot the rabbitmq cluster in staging.