### PR TITLE
Deprecate vm.reload_unicorn favour of app.reload

### DIFF
--- a/vm.py
+++ b/vm.py
@@ -1,4 +1,5 @@
 from fabric.api import *
+from fabric.utils import error
 import re
 
 @task
@@ -63,12 +64,7 @@ def bodge_unicorn(name):
 
 @task
 def reload_unicorn(name):
-    """
-    Gracefully reloads a named Unicorn process.
-
-    This is the same piped command we use when deploying applications.
-    """
-    sudo('sudo initctl start %s 2>/dev/null || sudo initctl reload %s' % (name, name))
+    error("task deprecated by 'app.reload'")
 
 def reboot_required():
     """


### PR DESCRIPTION
These two tasks do essentially the same thing. I think that `app.reload` is
preferable because it:

- has better documentation
- is namespaced in the right place, because this relates to a single app
  rather than a VM
- doesn't silently start the app if it isn't already running, which is
  something that I think we should know about when using a "reload" task
- uses `service` instead of `initctl` which abstracts upstart/sysvinit and
  correctly isolates environment variables from the calling shell