### PR TITLE
Specify locksmith hosts

### DIFF
--- a/locksmith.py
+++ b/locksmith.py
@@ -1,13 +1,16 @@
 from fabric.api import run, task
+import util
 
 etcd_cluster = 'http://etcd-1.management:4001,http://etcd-2.management:4001,http://etcd-3.management:4001'
 
 @task
 def status():
     """Get the status of locksmith"""
+    util.use_random_host('class-etcd')
     run("/usr/bin/locksmithctl -endpoint='{0}' status".format(etcd_cluster))
 
 @task
 def unlock(machine_name):
     """Unlock a machine with locksmith"""
+    util.use_random_host('class-etcd')
     run("/usr/bin/locksmithctl -endpoint='{0}' unlock '{1}'".format(etcd_cluster, machine_name))


### PR DESCRIPTION
These commands always need to run on an etcd-{1,2,3} machine, so pick a random host to run them on.