### PR TITLE
Remove runs_once decorator from cdn.purge_all

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -14,7 +14,6 @@ def fastly_purge(*args):
             run("curl -s -X PURGE -H 'Host: {0}' {1}{2}".format(hostname, govuk_fastly, govuk_path.strip()))
 
 @task
-@runs_once
 @roles('class-cache')
 def purge_all(*args):
     "Purge items from Fastly and cache machines, eg \"/one,/two,/three\""


### PR DESCRIPTION
We want to run `cache_purge` across all cache nodes. This decorator was added to prevent calling Fastly from purging multiple times, but it's unnecessary because the `fastly_purge` job has the same decorator.