### PR TITLE
Use execute to run other tasks from cdn.purge_all

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -14,9 +14,7 @@ def fastly_purge(*args):
             run("curl -s -X PURGE -H 'Host: {0}' {1}{2}".format(hostname, govuk_fastly, govuk_path.strip()))
 
 @task
-@runs_once
-@roles('class-cache')
 def purge_all(*args):
     "Purge items from Fastly and cache machines, eg \"/one,/two,/three\""
-    cache_purge(*args)
-    fastly_purge(*args)
+    execute(cache_purge, *args)
+    execute(fastly_purge, *args)


### PR DESCRIPTION
`execute` runs the task as if it were run from the command line, assembling the
list of hosts separately for each one. That means that we avoid the confusion
of `@roles` and `@runs_once` potentially conflicting, because they aren't needed
at all for `purge_all`.