### PR TITLE
Look for '200 Purged' in cache.purge output

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -5,7 +5,7 @@ from fabric.api import *
 def purge(*args):
     "Purge items from varnish, eg \"/one,/two,/three\""
     for path in args:
-        run("curl -s -I -X PURGE http://localhost:7999%s" % path.strip())
+        run("curl -s -I -X PURGE http://localhost:7999%s | grep '200 Purged'" % path.strip())
 
 @task
 @roles('class-cache')

--- a/cdn.py
+++ b/cdn.py
@@ -11,7 +11,7 @@ def fastly_purge(*args):
     hostnames_to_purge = ['www.gov.uk', 'assets.digital.cabinet-office.gov.uk']
     for govuk_path in args:
         for hostname in hostnames_to_purge:
-            run("curl -s -X PURGE -H 'Host: {0}' {1}{2}".format(hostname, govuk_fastly, govuk_path.strip()))
+            run("curl -s -X PURGE -H 'Host: {0}' {1}{2} | grep 'ok'".format(hostname, govuk_fastly, govuk_path.strip()))
 
 @task
 def purge_all(*args):


### PR DESCRIPTION
If the command succeeds we should see output like:

```
[cache-3.router] out: HTTP/1.1 200 Purged
[cache-3.router] out:
[cache-3.router] out: Server: Varnish
[cache-3.router] out:
[cache-3.router] out: Content-Type: text/html; charset=utf-8
[cache-3.router] out:
[cache-3.router] out: Retry-After: 5
[cache-3.router] out:
[cache-3.router] out: Content-Length: 380
[cache-3.router] out:
[cache-3.router] out: Accept-Ranges: bytes
[cache-3.router] out:
[cache-3.router] out: Date: Fri, 08 May 2015 13:51:59 GMT
[cache-3.router] out:
[cache-3.router] out: X-Varnish: 1941001298
[cache-3.router] out:
[cache-3.router] out: Age: 0
[cache-3.router] out:
[cache-3.router] out: Via: 1.1 varnish
[cache-3.router] out:
[cache-3.router] out: Connection: close
[cache-3.router] out:
[cache-3.router] out: X-Cache: MISS
[cache-3.router] out:
[cache-3.router] out:
[cache-3.router] out:
[cache-3.router] out:
```

This is very verbose when running the command across multiple cache
nodes.

This commit `grep`s for `200 Purged`, which has the following benefits:

- It makes the output smaller
- It will exit non-0 if it can't find any matching lines, which means
  the command will fail and notify us if the response doesn't match
  expectations