### PR TITLE
Clean up public task namespace

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -1,6 +1,6 @@
 from fabric.api import *
 
-from cache import purge as cache_purge
+import cache
 
 @task
 @runs_once
@@ -16,5 +16,5 @@ def fastly_purge(*args):
 @task
 def purge_all(*args):
     "Purge items from Fastly and cache machines, eg \"/one,/two,/three\""
-    execute(cache_purge, *args)
+    execute(cache.purge, *args)
     execute(fastly_purge, *args)

--- a/vm.py
+++ b/vm.py
@@ -2,6 +2,8 @@ from fabric.api import *
 from fabric.utils import error
 import re
 
+import nagios
+
 @task
 def uptime():
     """Show uptime and load"""
@@ -89,8 +91,7 @@ def reboot():
 @task
 def force_reboot():
   """Schedule a host for downtime in nagios and force reboot (even if not required)"""
-  from nagios import schedule_downtime
-  execute(schedule_downtime, env['host_string'])
+  execute(nagios.schedule_downtime, env['host_string'])
   run("sudo shutdown -r now")
 
 @task
@@ -100,8 +101,7 @@ def poweroff():
   Usage:
   fab production -H frontend-1.frontend.production vm.poweroff
   """
-  from nagios import schedule_downtime
-  execute(schedule_downtime, env['host_string'])
+  execute(nagios.schedule_downtime, env['host_string'])
   run("sudo poweroff")
 
 @task


### PR DESCRIPTION
Tasks imported into other Fabric task files are exposed publicly - see:

http://docs.fabfile.org/en/latest/usage/tasks.html#namespaces

This commit cleans up those imports so we don't pollute the public
namespace.

Fixes #120