### PR TITLE
[#93984644] Check whether locksmithctl is installed

### DIFF
--- a/locksmith.py
+++ b/locksmith.py
@@ -1,16 +1,25 @@
 from fabric.api import run, task
+from fabric.utils import error
+import fabric.contrib.files
 import util
 
 etcd_cluster = 'http://etcd-1.management:4001,http://etcd-2.management:4001,http://etcd-3.management:4001'
+locksmithctl = '/usr/bin/locksmithctl'
+
+def check_locksmithctl():
+    if not fabric.contrib.files.exists(locksmithctl):
+        error('locksmithctl is not installed. Perhaps unattended_reboots are disabled?')
 
 @task
 def status():
     """Get the status of locksmith"""
     util.use_random_host('class-etcd')
-    run("/usr/bin/locksmithctl -endpoint='{0}' status".format(etcd_cluster))
+    check_locksmithctl()
+    run("{0} -endpoint='{1}' status".format(locksmithctl, etcd_cluster))
 
 @task
 def unlock(machine_name):
     """Unlock a machine with locksmith"""
     util.use_random_host('class-etcd')
-    run("/usr/bin/locksmithctl -endpoint='{0}' unlock '{1}'".format(etcd_cluster, machine_name))
+    check_locksmithctl()
+    run("{0} -endpoint='{1}' unlock '{2}'".format(locksmithctl, etcd_cluster, machine_name))


### PR DESCRIPTION
When running tasks that depend on it. The package is uninstalled by Puppet
when `govuk_unattended_reboots::enabled` is false (default). This results in
the following output when a task is run:

    (fabric)➜  fabric-scripts git:(master) fab preview locksmith.status
    [etcd-1.management] run: /usr/bin/locksmithctl -endpoint='http://etcd-1.management:4001,http://etcd-2.management:4001,http://etcd-3.management:4001' status
    [etcd-1.management] out: /bin/bash: /usr/bin/locksmithctl: No such file or directory
    [etcd-1.management] out:

    Fatal error: run() received nonzero return code 127 while executing!

    Requested: /usr/bin/locksmithctl -endpoint='http://etcd-1.management:4001,http://etcd-2.management:4001,http://etcd-3.management:4001' status
    Executed: /bin/bash -l -c "/usr/bin/locksmithctl -endpoint='http://etcd-1.management:4001,http://etcd-2.management:4001,http://etcd-3.management:4001' status"

    Aborting.
    Disconnecting from etcd-1.management... done.
    Disconnecting from jumpbox.preview.alphagov.co.uk... done.

By checking whether the command is present first we can provide a simpler
error with more context:

    (fabric)➜  fabric-scripts git:(check_locksmithctl_installed) fab preview locksmith.status

    Fatal error: locksmithctl is not installed. Perhaps unattended_reboots are disabled?

    Aborting.
    Disconnecting from etcd-1.management... done.
    Disconnecting from jumpbox.preview.alphagov.co.uk... done.

I thought about decorating this with `@runs_once` but actually we probably
won't call locksmith multiple times in the same run, we'd want to check for
every machine it's run on, and it's pretty cheap to check.