### PR TITLE
Warn if repo hasn't been pulled recently

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -45,6 +45,10 @@ SSH_DIR = os.path.join(HERE, '.ssh')
 # How old a local hosts file can be before we check for an update
 HOSTS_FILE_CACHE_TIME = 3600 * 24
 
+# When to warn that you haven't pulled the repo recently.
+REPO_OUTDATED_TIME = 3600 * 24 * 5
+REPO_OUTDATED_FILE = os.path.join(HERE, '.git/FETCH_HEAD')
+
 ABORT_MSG = textwrap.dedent("""
     You must select an environment before running this task, e.g.
 
@@ -193,6 +197,9 @@ def _known_hosts_outdated(local_filename, remote_filename):
 
     return local_checksum != remote_checksum
 
+def _check_repo_age():
+    if time.time() - os.path.getmtime(REPO_OUTDATED_FILE) > REPO_OUTDATED_TIME:
+        warn('Your fabric-scripts may be out-of-date. Please `git pull` the repo')
 
 def _set_gateway(name, draft=False):
     """
@@ -321,3 +328,4 @@ def sdo(command):
     sudo(command)
 
 env.roledefs = RoleFetcher()
+_check_repo_age()


### PR DESCRIPTION
This repo changes fairly frequently and what was best practice two weeks ago
may no longer be the case. I've often forgotten to update when rolling onto
2nd line or on-call and commands have changed.

So warn people that they should run `git pull` if `.git/FETCH_HEAD`, which
is updated each time you run `git pull` or `git fetch`, hasn't been modified
in the last 5 days.

This isn't perfect because `FETCH_HEAD` doesn't give any indication of what
branch a person is on or whether they have actually merged from the remote
head. It seems like an improvement nonetheless though.