### PR TITLE
Allow usage of $HOME/.ssh/config for each user

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -39,6 +39,8 @@ import topic_change
 import vm
 import whitehall
 
+env.use_ssh_config = True
+
 HERE = os.path.dirname(__file__)
 SSH_DIR = os.path.join(HERE, '.ssh')
 


### PR DESCRIPTION
My new GDS machine has a username of jamesabley. The initial machine
that I used at work was my personal one (used for my first 5 months) and
had a username of jabley. My first GDS machine also had a username of
jabley.

This change to the fabfile means that the entry in my $HOME/.ssh/config
file for `User` [1] is honoured, and I can do:

```fab production vm.disk -H some.host```

rather than:

```fab -u jabley production vm.disk -H some.host```

[1] https://github.com/alphagov/gds-boxen/blob/d25c24eec813f98653a60d7e2b57d48173f4d454/modules/people/templates/jabley/ssh_config#L52-L56