### PR TITLE
Add a reason when disabling Puppet

### DIFF
--- a/incident.py
+++ b/incident.py
@@ -6,7 +6,7 @@ import puppet
 @roles('class-cache')
 def fail_to_mirror():
     """Fails the site to the mirror"""
-    puppet.disable()
+    puppet.disable("Fabric fail_to_mirror task invoked")
     nginx.disable_vhost("www.gov.uk")
     nginx.hello_it()
     print("Disabled Puppet and www.gov.uk vhost, remember to re-enable and re-run puppet to restore previous state")


### PR DESCRIPTION
Otherwise, `puppet.disable()` will fail.