### PR TITLE
Adds recover_origin task to Fabric

### DIFF
--- a/incident.py
+++ b/incident.py
@@ -10,3 +10,11 @@ def fail_to_mirror():
     nginx.disable_vhost("www.gov.uk")
     nginx.force_restart()
     print("Disabled Puppet and www.gov.uk vhost, remember to re-enable and re-run puppet to restore previous state")
+
+@task
+@roles('class-cache')
+def recover_origin():
+    """Recovers GOV.UK to serve from origin after incident.fail_to_mirror has been invoked"""
+    puppet.enable()
+    puppet.agent("--test")
+    print("Puppet has been re-enabled, has run and the site should now be serving from origin as normal.")


### PR DESCRIPTION
Whilst we can fail the site to mirrors easily using Fabric, we can't restore
as easily - at least, it's not a super-quick Fabric script.

This makes a nice quick fix. The logic is as follows:

  - Re-enable Puppet on the affected class
  - Run Puppet, with some degree of verbosity for confidence
   - This should restore the www.gov.uk Nginx vhost
     - This should restart Nginx because the configuration has changed
  - Prints a success message

Changes the fail_to_mirror success message to point to using this task in
future to restore from the mirrors.