### PR TITLE
Delete default vhost as well as www.gov.uk

### DIFF
--- a/incident.py
+++ b/incident.py
@@ -8,5 +8,6 @@ def fail_to_mirror():
     """Fails the site to the mirror"""
     puppet.disable("Fabric fail_to_mirror task invoked")
     nginx.disable_vhost("www.gov.uk")
+    nginx.disable_vhost("default")
     nginx.hello_it()
-    print("Disabled Puppet and www.gov.uk vhost, remember to re-enable and re-run puppet to restore previous state")
+    print("Disabled Puppet and www.gov.uk and default vhosts, remember to re-enable and re-run puppet to restore previous state")


### PR DESCRIPTION
For discussion:

This PR will fix the `inicident.fail_to_mirror` task, which currently fails using the default Fabric configuration to fail early on errors. I've tested this on Staging.

I think this failure highlights that deleting individual vhosts may be too brittle, so it might be preferable just to stop the nginx service. Suggestions welcome.

* * *

Delete the default Nginx virtual host as well as the `www.gov.uk`
virtual host.

The default virtual host references the `varnish` upstream which is
defined in the `www.gov.uk` virtual host, meaning that nginx fails to
start if the `www.gov.uk` is not present because it can't find the
`varnish` backend.

This means that the Fabric task `incident.fail_to_mirror` only stops
Nginx on the first cache node; Fabric will not continue to the other
cache nodes because `sudo service nginx start` returns a non-zero exit
code.

It looks like this has been broken since
https://github.gds/gds/puppet/commit/baef41223501337005f1efa4342e01fffaa0139c.