### PR TITLE
Rename nginx.hello_it to nginx.force_restart

### DIFF
--- a/incident.py
+++ b/incident.py
@@ -8,5 +8,5 @@ def fail_to_mirror():
     """Fails the site to the mirror"""
     puppet.disable("Fabric fail_to_mirror task invoked")
     nginx.disable_vhost("www.gov.uk")
-    nginx.hello_it()
+    nginx.force_restart()
     print("Disabled Puppet and www.gov.uk vhost, remember to re-enable and re-run puppet to restore previous state")

--- a/nginx.py
+++ b/nginx.py
@@ -31,7 +31,7 @@ def start():
     sudo('service nginx start')
 
 @task
-def hello_it():
+def force_restart():
     """Turns Nginx off and on again"""
     kill()
     start()


### PR DESCRIPTION
While I'm a fan of The IT Crowd, cultural references aren't useful as
descriptive method names.

It also excludes anyone not familiar with the brilliance of [Street
Countdown](https://www.youtube.com/watch?v=kYj1Gb3qQc0).