### PR TITLE
Stop nginx to fail to mirror

### DIFF
--- a/incident.py
+++ b/incident.py
@@ -5,7 +5,7 @@ import puppet
 @task
 @roles('class-cache')
 def fail_to_mirror():
-    """Fails the site to the mirror"""
+    """Fails the site to the mirror by stopping nginx on the cache nodes"""
     puppet.disable("Fabric fail_to_mirror task invoked")
     nginx_kill()
     print("Disabled Puppet and www.gov.uk vhost, remember to re-enable and re-run puppet to restore previous state")

--- a/incident.py
+++ b/incident.py
@@ -7,8 +7,7 @@ import puppet
 def fail_to_mirror():
     """Fails the site to the mirror"""
     puppet.disable("Fabric fail_to_mirror task invoked")
-    nginx.disable_vhost("www.gov.uk")
-    nginx.force_restart()
+    nginx_kill()
     print("Disabled Puppet and www.gov.uk vhost, remember to re-enable and re-run puppet to restore previous state")
 
 @task

--- a/nginx.py
+++ b/nginx.py
@@ -16,11 +16,6 @@ def gracefulrestart():
     start()
 
 @task
-def disable_vhost(vhost_filename):
-    """Disable a vhost by removing its symlink from /etc/nginx/sites-enabled"""
-    sudo('rm -f /etc/nginx/sites-enabled/%s' % vhost_filename)
-
-@task
 def kill():
     """Shut down Nginx immediately without waiting for it to finish running"""
     sudo('service nginx stop')


### PR DESCRIPTION
...rather than deleting a virtual host and restarting nginx.

We made this task more selective in 338b449 to prevent the Assets
virtual host from being disabled [1]. Since then, we now support
failover for `assets.digital.cabinet-office.gov.uk` [2], so this is no
longer an issue.

Prefer stopping nginx entirely as it's the simplest thing to do and
means we're not coupling this task to our Nginx virtual host
configuration.

[1]: #21 (comment)
[2]: https://github.gds/gds/cdn-configs/commit/8ca1877f55806f6d2f5ce3fb0d95b0142b7fa503#diff-e2f1431e532ca56328341b841c0cdaaf