### PR TITLE
Add a postgres sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,15 @@ and ensure that you do not have the following option anywhere in your
 `~/.ssh/config`:
 
     ForwardAgent yes
+
+## Syncing postgres machines
+
+An example
+
+`fab <env> -H '<src_db>' postgresql.sync:<db_name>,<dst_db> -A`
+
+the -A must be specified to forward the agent
+
+This will sync the specified database `<db_name>` from the machine with the
+hostname of `<src_db>` to the machine with hostaname `<dst_db>`. It will destroy
+data on the destination db

--- a/fabfile.py
+++ b/fabfile.py
@@ -30,6 +30,7 @@ import mysql
 import nagios
 import nginx
 import ntp
+import postgresql
 import puppet
 import rabbitmq
 import rkhunter

--- a/postgresql.py
+++ b/postgresql.py
@@ -1,0 +1,16 @@
+from fabric.api import task, sudo, env, settings, run
+from fabric.utils import abort
+
+@task
+def sync(database, dest_machine):
+    # the agent forwarding is required for the ssh command to the destination
+    # postgres server to work - this saves copying a temporary file down and
+    # back up again. We cant use fabrics sudo context manager because the
+    # command after the pipe should not run as the postgres user.
+    # The combination of "--schema public" and "--clean" in the pg_restore
+    # command clears all existing tables in the public schema before restoring
+    # the tables and data
+    with settings(forward_agent=True):
+        run('sudo -iupostgres pg_dump -Fc {0} | ssh {1} '
+            '"sudo -upostgres pg_restore --clean --single-transaction '
+            '--schema public --dbname {0}"'.format(database, dest_machine))


### PR DESCRIPTION
This relies on agent forwarding to save copying a temporary file down to
where the script is running and back up again. This is temporarily
enabled with a fabric command switch.

This runs pg_dump to dump the database on the source machine and pipes
it to postgres running on the destination machine - as the two sides of
the pipeline run as different users fabrics sudo decorator cannot be
used.