### PR TITLE
Elasticsearch safe reboot

### DIFF
--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -5,24 +5,28 @@ import json
 import re
 import vm
 
+
 @task
 def delete(index):
     """Delete an index"""
     if re.match('^[^/]+$', index):
-      run("curl -XDELETE 'http://localhost:9200/%s'" % index)
+        run("curl -XDELETE 'http://localhost:9200/%s'" % index)
     else:
-      abort("Invalid index provided '%s'" % index)
+        abort("Invalid index provided '%s'" % index)
+
 
 @task
 def status(index):
     """Get the status of an index"""
     run("curl -XGET 'http://localhost:9200/%s/_status'" % index)
 
+
 @task
 def cluster_health():
     """Get cluster status"""
     return run("curl -XGET 'http://localhost:9200/_cluster/health?pretty'",
                warn_only=True)
+
 
 @task
 def cluster_nodes():

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -95,7 +95,6 @@ def wait_for_status(*allowed):
 
 @task
 @serial
-@runs_once
 def safe_reboot():
     """Reboot only if the cluster is currently green"""
     import vm
@@ -112,12 +111,16 @@ def safe_reboot():
         # Give the reboot time to start, before we check for the status again.
         sleep(10)
 
-        # Status won't usually go back to green while reallocation is turned off,
-        # but should go to yellow.
+        # Status won't usually go back to green while reallocation is turned
+        # off, but should go to yellow.
         wait_for_status("green", "yellow")
         enable_reallocation()
     except:
-        print "Failed to re-enable allocation - you will need to enable it again using the 'elasticsearch.enable_reallocation' fabric command"
+        print(
+            "Failed to re-enable allocation - "
+            "you will need to enable it again using the "
+            "'elasticsearch.enable_reallocation' fabric command"
+        )
         raise
 
 


### PR DESCRIPTION
Under some conditions (eg. shortly after a reboot) fabric will prompt for a password when trying to ssh onto a machine. The abort_on_prompts setting causes this to raise an exception rather than just hang. This means that the tasks can be called sooner and slow starts do not cause a safe reboot to hang. It's a bit nasty because abort_on_prompts raises a SystemError which needs to be caught explicitly due to not inheriting from Exception. This is likely to change in Fabric 2.

This change also hides a lot of wait_for_status output. Given that it tends to run for quite a few iterations having lots of output can make it hard to spot the important details.

With a more robust `wait_for_status` and given that `safe_reboot` waits for the cluster to be green, we can now run `safe_reboot` over an elasticsearch cluster with something like:

`fab staging puppet_class:govuk::node::s_api_elasticsearch elasticsearch.safe_reboot`

I have tested this on a staging and with no problems.

cc/ @rboulton 