### PR TITLE
Fix warnings from ssh user home directory

### DIFF
--- a/performanceplatform.py
+++ b/performanceplatform.py
@@ -1,4 +1,4 @@
-from fabric.api import (cd, task, hosts, sudo)
+from fabric.api import (task, hosts, run)
 
 
 @task
@@ -24,8 +24,4 @@ def unpublish_dashboard(slug):
 
 
 def run_stagecraft_postgres_command(sql_command):
-    with cd('/'):
-        # Run this command from the root directory so that we don't see errors
-        # accessing the users
-        # home directory as the postgres user.
-        sudo('psql stagecraft -c "{0}"'.format(sql_command), user='postgres')
+    run('sudo -iu postgres psql stagecraft -c "{0}"'.format(sql_command))


### PR DESCRIPTION
The cd does not get rid of the warnings. This does. We use run as the
sudo() function does not support -i.

It's worth noting that these fab tasks did work but the warnings are
distracting and misleading.