### PR TITLE
Warn if attempting wildcard purge

### DIFF
--- a/cdn.py
+++ b/cdn.py
@@ -1,4 +1,5 @@
 from fabric.api import *
+from fabric.utils import abort
 
 import cache
 
@@ -6,9 +7,15 @@ import cache
 @runs_once
 @roles('class-cache')
 def fastly_purge(*args):
-    "Purge items from Fastly, eg \"/one,/two,/three\""
+    "Purge items from Fastly, eg \"/one,/two,/three\". Wildcards not supported."
     govuk_fastly = 'http://www-gov-uk.map.fastly.net'
     hostnames_to_purge = ['www.gov.uk', 'assets.digital.cabinet-office.gov.uk']
+    for path in args:
+        if "*" in path:
+            abort("Sorry, purging paths containing wildcards is not supported "
+                "(you requested to purge '%s'). "
+                "See https://github.gds/pages/gds/opsmanual/2nd-line/cache-flush.html?highlight=fastly#purging-a-page-from-fastly-with-fabric"
+                % path)
     for govuk_path in args:
         for hostname in hostnames_to_purge:
             run("curl -s -X PURGE -H 'Host: {0}' {1}{2} | grep 'ok'".format(hostname, govuk_fastly, govuk_path.strip()))


### PR DESCRIPTION
Fastly does not support general purpose wildcard purging. There is some
support for wildcard purging, but the wildcard must have been set up in
advance[1].

For the sake of clarity, issue a warning and abort execution if an
attempt is made to purge using a wildcard.

https://www.pivotaltracker.com/story/show/98271970

[1] https://docs.fastly.com/guides/purging/wildcard-purges