### PR TITLE
Fix host splitting

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -96,7 +96,7 @@ class RoleFetcher(object):
 
         for host in self.hosts:
             try:
-                name, vdc, _ = host.split('.', 3)
+                name, vdc, _ = host.split('.', 2)
             except ValueError:
                 warn("discarding badly formatted hostname '{0}'".format(host))
                 continue


### PR DESCRIPTION
The second parameter to `str.split()` is the maximum number of splits
to do, which means the list will have at most that many plus one
elements.

For strings which have more than 2 dots this causes an unintended
ValueError.

For example:

```
>>> host, vdc, _ = 'host-1.vdc.env'.split('.', 3)
>>> host, vdc, _ = 'host-1.vdc.env.computers.gov.uk'.split('.', 3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: too many values to unpack
>>> host, vdc, _ = 'host-1.vdc.env.computers.gov.uk'.split('.', 2)
```