### PR TITLE
Prevent puppet being put in the mapit namespace

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -12,6 +12,9 @@ from fabric.api import (abort, env, get, hide, hosts, local, puts, run,
                         runs_once, serial, settings, sudo, task, warn)
 from fabric.task_utils import crawl
 
+# Other submodules such as mapit depend on puppet, so include this one first
+import puppet
+
 # Our command submodules
 import app
 import apt
@@ -33,7 +36,6 @@ import nginx
 import ntp
 import performanceplatform
 import postgresql
-import puppet
 import rabbitmq
 import rkhunter
 import search


### PR DESCRIPTION
Because the mapit tasks depend on puppet, they import puppet.

However, this was confusing fabric which relies on the order of module
importing to determine the task namespaces.

```
$ fab -l | grep puppet 
    mapit.puppet                                             Run puppet agent
    mapit.puppet.agent                                       Run puppet agent
    mapit.puppet.check_disabled                              Check if puppet ...
    mapit.puppet.disable                                     Disable puppet r...
    mapit.puppet.dryrun                                      Run puppet agent...
    mapit.puppet.enable                                      Enable puppet ru...
    mapit.puppet.loadhosts                                   Deprecated, use ...
    mapit.puppet.lookup_hieradata
```

To fix this, import puppet first before other submodules.