### PR TITLE
Fix nagios_hostname validity checks for new naming

### DIFF
--- a/nagios.py
+++ b/nagios.py
@@ -16,13 +16,20 @@ def submit_nagios_cmd(command):
 def _nagios_hostname(host):
     """Returns the canonical name (according to nagios) for a host"""
     name_parts = string.split(host,'.')
-    env_expected_name_length = 7 if (('preview' in name_parts) | ('staging' in name_parts)) else 6
     if len(name_parts) == 1:
         raise ValueError("Shortnames not supported for nagios commands")
-    elif len(name_parts) > env_expected_name_length:
+    elif 'service' in name_parts:
+        env_expected_name_length = 7 if (('preview' in name_parts) | ('staging' in name_parts)) else 6
+        if len(name_parts) > env_expected_name_length:
+            raise ValueError("Don't understand name of nagios host: %s" % host)
+        elif len(name_parts) == env_expected_name_length:
+            return host
+    elif len(name_parts) > 3:
         raise ValueError("Don't understand name of nagios host: %s" % host)
-    elif len(name_parts) == env_expected_name_length:
+    elif len(name_parts) == 3:
         return host
+    elif len(name_parts) == 2:
+        return "%s.production" % host
 
 
 @task

--- a/nagios.py
+++ b/nagios.py
@@ -16,14 +16,13 @@ def submit_nagios_cmd(command):
 def _nagios_hostname(host):
     """Returns the canonical name (according to nagios) for a host"""
     name_parts = string.split(host,'.')
-    if len(name_parts) > 3:
-        raise ValueError("Don't understand name of nagios host: %s" % host)
-    elif len(name_parts) == 3:
-        return host
-    elif len(name_parts) == 2:
-        return "%s.production" % host
-    elif len(name_parts) == 1:
+    env_expected_name_length = 7 if (('preview' in name_parts) | ('staging' in name_parts)) else 6
+    if len(name_parts) == 1:
         raise ValueError("Shortnames not supported for nagios commands")
+    elif len(name_parts) > env_expected_name_length:
+        raise ValueError("Don't understand name of nagios host: %s" % host)
+    elif len(name_parts) == env_expected_name_length:
+        return host
 
 
 @task


### PR DESCRIPTION
Since renaming all the things for the Carrenza
migration, we need to adjust these validity checks
against the `host`. Staging/Preview environments
when split on ‘.’ have 7 elements as they contain
the environment in the FQDN, whereas production
does not contain the environment in the FQDN and
hence has only 6 elements.