### PR TITLE
Make varnish cache purge tasks purge draft caches

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,14 +1,14 @@
 from fabric.api import *
 
 @task
-@roles('class-cache')
+@roles('class-cache', 'class-draft_cache')
 def purge(*args):
     "Purge items from varnish, eg \"/one,/two,/three\""
     for path in args:
         run("curl -s -I -X PURGE http://localhost:7999%s | grep '200 Purged'" % path.strip())
 
 @task
-@roles('class-cache')
+@roles('class-cache', 'class-draft_cache')
 def restart():
     """
     Restart Varnish caches
@@ -16,7 +16,7 @@ def restart():
     sudo('/etc/init.d/varnish restart')
 
 @task(default=True)
-@roles('class-cache')
+@roles('class-cache', 'class-draft_cache')
 def stats():
     "Show details about varnish performance"
     sudo('varnishstat -1')


### PR DESCRIPTION
modify these tasks to purge the draft caches as well as the live ones.

I couldn't think of a scenario in which it would be important to only
purge one set of caches and not the other, so I've just made it default
to purging both live and draft.