### PR TITLE
Allow specifying multiple classes at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ And execute against an environment and set of hosts like so:
     $ fab preview all hosts
     ...
     $ fab preview class:frontend do:'uname -a'
+    $ fab preview class:cache,bouncer do:uptime
     ...
 
 ### Targetting groups of machines

--- a/fabfile.py
+++ b/fabfile.py
@@ -263,9 +263,10 @@ def numbered(number):
     env.hosts = [host for host in env.hosts if re.search((r'-%s\.' % number), host)]
 
 @task(name='class')
-def klass(class_name):
+def klass(*class_names):
     """Select a machine class"""
-    env.hosts.extend(env.roledefs['class-%s' % class_name]())
+    for class_name in class_names:
+        env.hosts.extend(env.roledefs['class-%s' % class_name]())
 
 @task
 @serial


### PR DESCRIPTION
This was previously possible by doing:

```
fab production class:cache class:bouncer do:uptime
```

But that would run the `class` task for bouncer on each of the cache machines (which is not a problem, just noisy).

This commit changes the parameter to the `class` task so that multiple arguments can be passed in.