### PR TITLE
Update puppet_class to take multiple classes

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -271,10 +271,11 @@ def klass(*class_names):
 @task
 @serial
 @hosts('localhost')
-def puppet_class(class_name):
+def puppet_class(*class_names):
     """Select all machines which include a given puppet class"""
-    env.roledefs.fetch_puppet_class(class_name)
-    env.hosts.extend(env.roledefs['puppet_class-%s' % class_name]())
+    for class_name in class_names:
+        env.roledefs.fetch_puppet_class(class_name)
+        env.hosts.extend(env.roledefs['puppet_class-%s' % class_name]())
 
 @task
 @hosts('localhost')

--- a/puppet.py
+++ b/puppet.py
@@ -1,11 +1,5 @@
 from fabric.api import *
 
-@task
-def loadhosts(*classnames):
-    """Deprecated, use puppet_class"""
-    usage = ["puppet_class:{0}".format(name) for name in classnames]
-    abort("puppet.loadhosts is deprecated, use: {0}".format(" ".join(usage)))
-
 def puppet(*args):
     sudo('govuk_puppet %s' % ' '.join(args))
 


### PR DESCRIPTION
Similar to b2f93a911dec5d8ebe0d07b7870e7a57949d0b54, this commit uses the same logic when selecting `puppet_class`.