### PR TITLE
Update rkhunter check task

### DIFF
--- a/rkhunter.py
+++ b/rkhunter.py
@@ -3,7 +3,7 @@ from fabric.api import *
 @task(default=True)
 def check(*args):
     """Run rkhunter on the machine"""
-    sudo('/usr/bin/rkhunter --cronjob --report-warnings-only --appendlog')
+    sudo('/etc/cron.daily/rkhunter-passive-check')
 
 @task
 def propupdate(*args):


### PR DESCRIPTION
Update the check to use the script that we run daily. This Fabric script will mostly be run by people who want to solve a passive check alert for rkhunter, so we should make sure that the task does actually update the passive check.