### PR TITLE
Improve `nagios.loadhosts`

### DIFF
--- a/nagios.py
+++ b/nagios.py
@@ -77,7 +77,14 @@ def loadhosts(search_string=''):
         url = prompt("Icinga URL (jsonformat): ")
 
     with hide('running', 'stdout'):
-        resp = run('curl --insecure "{0}"'.format(url))
+        status_code = run('curl --silent --write-out "%{{http_code}}" --output /dev/null --insecure "{0}"'.format(url))
+        if status_code == '200':
+            resp = run('curl --insecure "{0}"'.format(url))
+        elif status_code == '401':
+            basic_auth_password = prompt('HTTP basic auth password: ')
+            resp = run('curl --user betademo:{1} --insecure "{0}"'.format(url, basic_auth_password))
+        else:
+            abort('Could not connect to monitoring service')
 
     hosts = [
         service['host_name'].split('.production').pop(0)


### PR DESCRIPTION
My typical use case is searching for unhandled problems in Icinga and running a task on all machines which match.

Instead of having to find an Icinga URL that outputs JSON it would be more useful for me to only provide a search string.

This commit changes from using the `requests` library locally to running curl on the remote machine.

I've also added the `@hosts` decorator to this task so that a machine to run it on doesn't have to be provided.

---

Feedback on whether this is a good idea is welcome.