### PR TITLE
Add a task to setup MySQL replication

### DIFF
--- a/mysql.py
+++ b/mysql.py
@@ -36,3 +36,36 @@ def fix_replication_from_slow_query_log_after_upgrade():
     run_mysql_command("START SLAVE;")
     run_mysql_command("SET GLOBAL slow_query_log = 'ON';")
     run_mysql_command("show slave status\G;")
+
+
+@task
+def setup_slave_from_master(master):
+    """
+    Sets up a slave from a master by taking a dump from the master,
+    copying it to the slave and then restoring the dump.
+
+    Usage: fab environment -H mysql-slave-1.backend mysql.setup_slave_from_master:'mysql-master-1.backend'
+    """
+    if len(env.hosts) > 1:
+        print 'This job is currently only setup to run against one slave at a time'
+
+    with settings(host_string=master):
+        # The use of `--master-data` here implies `--lock-all-tables` per the
+        # MySQL reference manual: http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_master-data
+        run('sudo -i mysqldump -u root --all-databases --master-data --add-drop-database > dump.sql')
+
+    with settings(host_string=master, forward_agent=True):
+        run('scp dump.sql {0}:~'.format(env.hosts[0]))
+
+    with settings(host_string=master):
+        run('rm dump.sql')
+
+    run_mysql_command("STOP SLAVE")
+    run_mysql_command("SET GLOBAL slow_query_log=OFF")
+
+    run('sudo -i mysql -uroot < dump.sql')
+
+    run_mysql_command("START SLAVE")
+    run_mysql_command("SET GLOBAL slow_query_log=ON")
+
+    run_mysql_command("SHOW SLAVE STATUS\G")


### PR DESCRIPTION
This replaces a [list of commands in the opsmanual](https://github.gds/pages/gds/opsmanual/infrastructure/howto/setup-mysql-replication.html) with code.

I've used `run('sudo -i ...')` because `sudo()` doesn't appear to support simulating a login shell.

I've only set this up to run against one slave at a time because doing more than one is a bit more complicated and this is still better than what we have at the moment.