### PR TITLE
[FOR DISCUSSION ONLY] Move logdump.py script into Fabric

### DIFF
--- a/elasticsearch_logdump.py
+++ b/elasticsearch_logdump.py
@@ -1,0 +1,109 @@
+"""
+Connect to an ElasticSearch cluster containing log data (e.g.  our
+logs-elasticsearch cluster) and dump records matching a specified query in CSV
+format.
+
+e.g. dump the fields "@fields.request" and "@fields.request_time" for all log
+     entries matching the query
+
+         @fields.application:whitehall-admin AND @tags:nginx
+
+     from dates between midnight on 2013-05-13 and midnight on 2013-05-20:
+
+         python logdump.py --from 2013-05-13T00:00:00Z \
+                           --to 2013-05-20T00:00:00Z \
+                           --fields @fields.request @fields.request_time \
+                           --query '@fields.application:whitehall-admin AND @tags:nginx'
+"""
+import argparse
+import csv
+import datetime
+import functools
+import json
+import sys
+
+import requests
+
+BATCH_SIZE = 200
+DATE_FMT = "%Y-%m-%dT%H:%M:%SZ"
+ES_ROOT = 'http://127.0.0.1:9200'
+
+class LogQuery(object):
+
+    def __init__(self, query, date_from, date_to, fields=None, index='logs'):
+        self.query = query
+        self.date_from = date_from
+        self.date_to = date_to
+        self.fields = fields
+        self.index = index
+
+    def results(self):
+        days = (self.date_to - self.date_from).days
+
+        for i in range(days + 1):
+            for item in self._results_for_day(i):
+                yield item
+
+    def _results_for_day(self, day):
+        index_date = self.date_from + datetime.timedelta(days=day)
+        index_name = self.index + '-' + index_date.strftime('%Y.%m.%d')
+
+        payload = {
+            'query': self._build_query(),
+            'size': BATCH_SIZE,
+            'sort': [{ '@timestamp': 'asc' }],
+        }
+        if self.fields:
+            payload['fields'] = self.fields
+
+        req = functools.partial(requests.get,
+                                ES_ROOT + '/' + index_name + '/_search')
+
+        read = 0
+        while True:
+            payload['from'] = read
+
+            resp = req(data=json.dumps(payload))
+            resp.raise_for_status()
+
+            data = resp.json()
+
+            for item in data['hits']['hits']:
+                read += 1
+                if self.fields:
+                    yield {k: ','.join(v) for k, v in item['fields'].items()}
+                else:
+                    result = {}
+                    for k, v in item['_source'].items():
+                        if isinstance(v, basestring):
+                            result[k] = v
+                        else:
+                            result[k] = json.dumps(v)
+                    yield result
+
+            if data['hits']['total'] <= read:
+                break
+
+    def _build_query(self):
+        q_query = {
+            'query_string': {
+                'default_operator': 'OR',
+                'default_field': '@message',
+                'query': self.query,
+            }
+        }
+        q_filter = {
+            'range': {
+                '@timestamp': {
+                    'from': self.date_from.strftime(DATE_FMT),
+                    'to': self.date_to.strftime(DATE_FMT),
+                }
+            }
+        }
+        q = {
+            'filtered': {
+                'query': q_query,
+                'filter': q_filter,
+            }
+        }
+        return q

--- a/forward_tunnel.py
+++ b/forward_tunnel.py
@@ -1,0 +1,57 @@
+import SocketServer, paramiko, threading, select
+
+class ForwardServer (SocketServer.ThreadingTCPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+class Handler (SocketServer.BaseRequestHandler):
+    def handle(self):
+
+        try:
+            chan = self.ssh_transport.open_channel('direct-tcpip',
+                    (self.chain_host, self.chain_port),
+                    self.request.getpeername())
+        except Exception, e:
+            print('Incoming request to %s:%d failed: %s' % (self.chain_host,
+                self.chain_port,
+                repr(e)))
+            return
+        if chan is None:
+            print('Incoming request to %s:%d was rejected by the SSH server.' %
+                    (self.chain_host, self.chain_port))
+            return
+
+        print('Connected!  Tunnel open %r -> %r -> %r' % (self.request.getpeername(),
+            chan.getpeername(), (self.chain_host, self.chain_port)))
+        while True:
+            r, w, x = select.select([self.request, chan], [], [])
+            if self.request in r:
+                data = self.request.recv(1024)
+                if len(data) == 0:
+                    break
+                chan.send(data)
+            if chan in r:
+                data = chan.recv(1024)
+                if len(data) == 0:
+                    break
+                self.request.send(data)
+
+        peername = self.request.getpeername()
+        chan.close()
+        self.request.close()
+        print('Tunnel closed from %r' % (peername,))
+
+def forward_tunnel(local_port, remote_host, remote_port, transport):
+
+    # this is a little convoluted, but lets me configure things for the Handler
+    # object.  (SocketServer doesn't give Handlers any way to access the outer
+    # server normally.)
+
+    class SubHander (Handler):
+        chain_host = remote_host
+        chain_port = remote_port
+        ssh_transport = transport
+
+    server_thread = threading.Thread(target=ForwardServer(('', local_port), SubHander).serve_forever)
+    server_thread.daemon = True
+    server_thread.start()


### PR DESCRIPTION
This work-in-progress moves [logdump.py](https://github.gds/gds/private-utils/blob/master/logutils/logdump.py) from the private-utils repository into a Fabric task.

I've raised this pull request to solicit suggestions on this implementation, which so far is unsatisfactory due to the way it:

- uses four mandatory named arguments, e.g. `fab preview elasticsearch.dump_logs:'date_from=2015-09-02T00:00:00Z,date_to=2015-09-02T23:59:59Z,fields=@message,query=@fields.application:licensify'`
- tunnels a local port to the Elasticsearch cluster

I also did this work while on Second Line and don't want to lose the context, so raising here for discussion.

I'd really like to move this script from private-utils as it's the only remaining useful script in that repo (see [#30](https://github.gds/gds/private-utils/pull/30)), meaning the repo can be deprecated once this script is moved.