### PR TITLE
Stop `import`ing graphite

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -22,7 +22,6 @@ import cache
 import campaigns
 import cdn
 import elasticsearch
-import graphite
 import incident
 import licensify
 import locksmith


### PR DESCRIPTION
This project stopped using Graphite in https://github.com/alphagov/fabric-scripts/pull/161

The line reverted here and the changes reverted in #161 were originally introduced together in https://github.com/alphagov/fabric-scripts/pull/86