### PR TITLE
Remove decorators from campaign helper method

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -50,8 +50,6 @@ def template(app):
     env['template_contents'] = template.render(env.context)
 
 
-@task
-@roles('class-frontend')
 def deploy_banner(application):
     execute(template, application)
     if application == 'frontend':


### PR DESCRIPTION
Removing these decorators means that the methods still work the same but it no longer shows up in the list that `fab -l` outputs which reduces confusion and lets people deploy banners faster.