### PR TITLE
Add a task to put loadbalancers into maintenance

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -1,6 +1,28 @@
 from fabric.api import *
+import fabric.contrib.files
+import puppet
+
+maintenance_config = '/etc/nginx/includes/maintenance.conf'
 
 @task
+def enable_maintenance:
+    """Enables a maintenance page and serves a 503"""
+    """Only to be run on loadbalancers"""
+    if not fabric.contrib.files.exists(maintenance_config):
+        abort("Sorry this task can only currently be run on loadbalancers")
+    puppet.disable("Maintenance mode enabled")
+    sudo("echo 'set $maintenance 1;' > {0}".format(maintenance_config))
+    sudo('service nginx reload')
+
+def disable_maintenance:
+    """Disables a maintenance page"""
+    """Only to be run on loadbalancers"""
+    if not fabric.contrib.files.exists(maintenance_config):
+        abort("Sorry this task can only currently be run on loadbalancers")
+    sudo("echo 'set $maintenance 0;' > {0}".format(maintenance_config))
+    sudo('service nginx reload')
+    puppet.enable()
+
 def gracefulstop(wait=True):
     """Gracefully shutdown Nginx by finishing any in-flight requests"""
     sudo('nginx -s quit')


### PR DESCRIPTION
As part of migration we have added functionality
to the loadbalancer nginx module in puppet to put
said loadbalancer into maintenance mode by
toggling a $maintenance boolean value.

Currently this is only supported on the
loadbalancers.

See: https://github.gds/gds/puppet/pull/3405