### PR TITLE
Fix syntax

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -5,7 +5,7 @@ import puppet
 maintenance_config = '/etc/nginx/includes/maintenance.conf'
 
 @task
-def enable_maintenance:
+def enable_maintenance():
     """Enables a maintenance page and serves a 503"""
     """Only to be run on loadbalancers"""
     if not fabric.contrib.files.exists(maintenance_config):
@@ -14,7 +14,7 @@ def enable_maintenance:
     sudo("echo 'set $maintenance 1;' > {0}".format(maintenance_config))
     sudo('service nginx reload')
 
-def disable_maintenance:
+def disable_maintenance():
     """Disables a maintenance page"""
     """Only to be run on loadbalancers"""
     if not fabric.contrib.files.exists(maintenance_config):


### PR DESCRIPTION
Without these parentheses, `fab` fails with:

    fab
    Traceback (most recent call last):
      File "/opt/boxen/homebrew/lib/python2.7/site-packages/fabric/main.py", line 658, in main
        docstring, callables, default = load_fabfile(fabfile)
      File "/opt/boxen/homebrew/lib/python2.7/site-packages/fabric/main.py", line 165, in load_fabfile
        imported = importer(os.path.splitext(fabfile)[0])
      File "/Users/matt/govuk/fabric-scripts/fabfile.py", line 25, in <module>
        import incident
      File "/Users/matt/govuk/fabric-scripts/incident.py", line 3, in <module>
        import nginx
      File "/Users/matt/govuk/fabric-scripts/nginx.py", line 8
        def enable_maintenance:
                              ^
    SyntaxError: invalid syntax