### PR TITLE
Add task decorator to disable_maintenance

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -14,6 +14,7 @@ def enable_maintenance():
     sudo("echo 'set $maintenance 1;' > {0}".format(maintenance_config))
     sudo('service nginx reload')
 
+@task
 def disable_maintenance():
     """Disables a maintenance page"""
     """Only to be run on loadbalancers"""


### PR DESCRIPTION
So that it shows up when invoking `fab -l` and can be run as a normal
task.