### PR TITLE
[#104304078] Remove production_migration environment

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -231,12 +231,6 @@ def help(name):
 def production():
     """Select production environment"""
     env['environment'] = 'production'
-    _set_gateway('production.alphagov.co.uk')
-
-@task
-def production_migration():
-    """Select production migration environment"""
-    env['environment'] = 'production'
     _set_gateway('publishing.service.gov.uk')
 
 @task


### PR DESCRIPTION
This environment is now just production.

This should be merged when the old jumpbox is switched off.