### PR TITLE
Convert code to PEP8 and add lint/syntax check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+---
+language: "python"
+sudo: false # containerised builds
+install:
+  - "pip install -q -r requirements_for_tests.txt"
+script: "make test"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 test:
-	@flake8 . --exclude fabfile.py --ignore=E241,E501,F403
+	@flake8 . --exclude fabfile.py --ignore=E241,E501, \
+	  F403 # FIXME: Fix these errors and stop ignoring them
 	@flake8 fabfile.py --ignore=E241,E501,F401

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
-	@flake8 . --exclude fabfile.py --ignore=E501,F403
-	@flake8 fabfile.py --ignore=E501,F401
+	@flake8 . --exclude fabfile.py --ignore=E241,E501,F403
+	@flake8 fabfile.py --ignore=E241,E501,F401

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	@flake8 . --exclude fabfile.py --ignore=E501,F403
+	@flake8 fabfile.py --ignore=E501,F401

--- a/apt.py
+++ b/apt.py
@@ -1,19 +1,23 @@
 from fabric.api import *
 
+
 @task
 def updates():
     """Show package counts needing updates"""
     run("cat /var/lib/update-notifier/updates-available")
+
 
 @task
 def security_updates():
     """Show outstanding security updates"""
     run("/usr/local/bin/govuk_check_security_upgrades --human-readable")
 
+
 @task
 def upgrade():
     """Upgrade packages with apt-get"""
     sudo("apt-get update; apt-get upgrade -y")
+
 
 @task
 def dist_upgrade():
@@ -21,15 +25,18 @@ def dist_upgrade():
     prompt('dist-upgrade is a dangerous operation, can remove packages and generally break all the things. Are you sure you want to proceed? (y/n)', validate=r'^[Yy]$')
     sudo("apt-get -q update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" -yuq dist-upgrade")
 
+
 @task
 def unattended_upgrade():
     """Perform an unattended-upgrade"""
     sudo("unattended-upgrade -d")
 
+
 @task
 def unattended_upgrade_dry_run():
     """Perform an unattended-upgrade dry run"""
     sudo("unattended-upgrade -d --dry-run")
+
 
 @task(default=True)
 def packages_with_reboots(*args):
@@ -37,15 +44,18 @@ def packages_with_reboots(*args):
     package_reboot_file = '/var/run/reboot-required.pkgs'
     sudo('if [ -f {0} ]; then cat {0}; else echo No packages with reboots; fi'.format(package_reboot_file))
 
+
 @task
 def reset_reboot_needed(*args):
     """Delete the flag file that triggers the 'reboot required by apt' Nagios check"""
     sudo('rm -f /var/run/reboot-required')
 
+
 @task
 def autoremove():
     """Run `apt-get autoremove`"""
     sudo('apt-get autoremove')
+
 
 @task
 def autoremove_dry_run():

--- a/cache.py
+++ b/cache.py
@@ -1,11 +1,13 @@
 from fabric.api import *
 
+
 @task
 @roles('class-cache', 'class-draft_cache')
 def purge(*args):
     "Purge items from varnish, eg \"/one,/two,/three\""
     for path in args:
         run("curl -s -I -X PURGE http://localhost:7999%s | grep '200 Purged'" % path.strip())
+
 
 @task
 @roles('class-cache', 'class-draft_cache')
@@ -14,6 +16,7 @@ def restart():
     Restart Varnish caches
     """
     sudo('/etc/init.d/varnish restart')
+
 
 @task(default=True)
 @roles('class-cache', 'class-draft_cache')

--- a/campaigns.py
+++ b/campaigns.py
@@ -20,7 +20,7 @@ def validate_classes(campaign_class):
     """Checks that the campaign class is valid"""
     if campaign_class in CAMPAIGN_CLASSES:
         return campaign_class
-    raise Exception, "Invalid class {}, valid values are {}".format(campaign_class, CAMPAIGN_CLASSES)
+    raise Exception("Invalid class {}, valid values are {}".format(campaign_class, CAMPAIGN_CLASSES))
 
 
 @runs_once

--- a/campaigns.py
+++ b/campaigns.py
@@ -35,7 +35,7 @@ def set_context():
 
 def template(app):
     if app == 'frontend':
-      template = Template("""<div id="campaign" class="{{ campaign_class }}">
+        template = Template("""<div id="campaign" class="{{ campaign_class }}">
     <div class="campaign-inner">
       <h1>{{ heading|e }}</h1>
       <p>{{ extra_info|e }}</p>
@@ -43,7 +43,7 @@ def template(app):
     </div>
   </div>""")
     elif app == 'static':
-      template = Template("""<p>{{ heading|e }}<br />
+        template = Template("""<p>{{ heading|e }}<br />
     {{ extra_info|e }}</p>
   <a href="#" class="right">{{ more_info|e }}</a>""")
 
@@ -60,6 +60,7 @@ def deploy_banner(application):
     put(StringIO.StringIO(content), remote_filename, use_sudo=True, mirror_local_mode=True)
     sudo('chown deploy:deploy %s' % remote_filename)
     execute(app.reload, application)
+
 
 def remove_banner(application):
     if application == 'frontend':
@@ -83,6 +84,7 @@ def deploy_emergency_banner():
         # Don't deploy a black banner to the static application.
         if not (env.campaign_class == 'black' and application == 'static'):
             deploy_banner(application)
+
 
 @task
 @roles('class-frontend')

--- a/cdn.py
+++ b/cdn.py
@@ -3,6 +3,7 @@ from fabric.utils import abort
 
 import cache
 
+
 @task
 @runs_once
 @roles('class-cache')
@@ -16,12 +17,13 @@ def fastly_purge(*args):
     for path in args:
         if "*" in path:
             abort("Sorry, purging paths containing wildcards is not supported "
-                "(you requested to purge '%s'). "
-                "See https://github.gds/pages/gds/opsmanual/2nd-line/cache-flush.html?highlight=fastly#purging-a-page-from-fastly-with-fabric"
-                % path)
+                  "(you requested to purge '%s'). "
+                  "See https://github.gds/pages/gds/opsmanual/2nd-line/cache-flush.html?highlight=fastly#purging-a-page-from-fastly-with-fabric"
+                  % path)
     for govuk_path in args:
         for hostname in hostnames_to_purge:
             run("curl -s -X PURGE {0}{1} | grep 'ok'".format(hostname, govuk_path.strip()))
+
 
 @task
 def purge_all(*args):

--- a/fabfile.py
+++ b/fabfile.py
@@ -75,6 +75,7 @@ ABORT_MSG = textwrap.dedent("""
         fab production vdcs
     """)
 
+
 class RoleFetcher(object):
     """
     RoleFetcher is a helper class, an instance of which can be bound to the
@@ -138,6 +139,7 @@ class RoleFetcher(object):
         if not self.fetched:
             abort(ABORT_MSG)
 
+
 def _fetch_hosts(extra_args=''):
     """
     Fetch a list of hosts in this environment, regardless of whether we're
@@ -152,6 +154,7 @@ def _fetch_hosts(extra_args=''):
         # Otherwise assume we're *in* the infrastructure
         else:
             return local(list_cmd).splitlines()
+
 
 def _fetch_known_hosts():
     """
@@ -177,6 +180,7 @@ def _fetch_known_hosts():
 
     return known_hosts_file
 
+
 def _known_hosts_outdated(local_filename, remote_filename):
     """Check whether a local copy of a jumpbox hosts file is outdated.
 
@@ -201,11 +205,13 @@ def _known_hosts_outdated(local_filename, remote_filename):
 
     return local_checksum != remote_checksum
 
+
 def _check_repo_age():
     if not os.path.exists(REPO_OUTDATED_FILE):
         return
     if time.time() - os.path.getmtime(REPO_OUTDATED_FILE) > REPO_OUTDATED_TIME:
         warn('Your fabric-scripts may be out-of-date. Please `git pull` the repo')
+
 
 def _set_gateway(jumpbox_domain):
     """
@@ -217,6 +223,7 @@ def _set_gateway(jumpbox_domain):
     env.system_known_hosts = _fetch_known_hosts()
     env.roledefs.fetch()
 
+
 @task
 def help(name):
     """Show extended help for a task (e.g. 'fab help:search.reindex')"""
@@ -227,11 +234,13 @@ def help(name):
 
     puts(textwrap.dedent(task.__doc__).strip())
 
+
 @task
 def production():
     """Select production environment"""
     env['environment'] = 'production'
     _set_gateway('publishing.service.gov.uk')
+
 
 @task
 def staging():
@@ -239,16 +248,19 @@ def staging():
     env['environment'] = 'staging'
     _set_gateway('staging.publishing.service.gov.uk')
 
+
 @task
 def preview():
     """Select preview environment"""
     env['environment'] = 'preview'
     _set_gateway('preview.alphagov.co.uk')
 
+
 @task
 def all():
     """Select all machines in current environment"""
     env.hosts.extend(env.roledefs['all']())
+
 
 @task
 @runs_once
@@ -259,11 +271,13 @@ def numbered(number):
         abort("Unrecognised number: %s" % number)
     env.hosts = [host for host in env.hosts if re.search((r'-%s\.' % number), host)]
 
+
 @task(name='class')
 def klass(*class_names):
     """Select a machine class"""
     for class_name in class_names:
         env.hosts.extend(env.roledefs['class-%s' % class_name]())
+
 
 @task
 @serial
@@ -274,6 +288,7 @@ def puppet_class(*class_names):
         env.roledefs.fetch_puppet_class(class_name)
         env.hosts.extend(env.roledefs['puppet_class-%s' % class_name]())
 
+
 @task
 @hosts('localhost')
 def node_type(node_name):
@@ -281,10 +296,12 @@ def node_type(node_name):
     class_name = 'govuk::node::s_{}'.format(node_name.replace('-', '_'))
     puppet_class(class_name)
 
+
 @task
 def vdc(vdc_name):
     """Select a virtual datacentre"""
     env.hosts.extend(env.roledefs['vdc-%s' % vdc_name]())
+
 
 @task
 @runs_once
@@ -294,6 +311,7 @@ def hosts():
     hosts = me.get_hosts(None, None, None, env)
     print('\n'.join(sorted(hosts)))
 
+
 @task
 @runs_once
 def classes():
@@ -301,6 +319,7 @@ def classes():
     for name in sorted(env.roledefs.classes):
         hosts = env.roledefs['class-%s' % name]
         print("%-30.30s %s" % (name, len(hosts())))
+
 
 @task
 @runs_once
@@ -310,10 +329,12 @@ def vdcs():
         hosts = env.roledefs['vdc-%s' % name]
         print("%-30.30s %s" % (name, len(hosts())))
 
+
 @task
 def do(command):
     """Execute arbitrary commands"""
     run(command)
+
 
 @task
 def sdo(command):

--- a/incident.py
+++ b/incident.py
@@ -3,6 +3,7 @@ from fabric.tasks import execute
 import nginx
 import puppet
 
+
 @task
 @roles('class-cache')
 def fail_to_mirror():
@@ -11,6 +12,7 @@ def fail_to_mirror():
     execute(nginx.kill)
     print('Disabled Puppet and switched off Nginx.')
     print('Run `incident.recover_origin` to start serving from origin again.')
+
 
 @task
 @roles('class-cache')

--- a/licensify.py
+++ b/licensify.py
@@ -1,5 +1,6 @@
 from fabric.api import *
 
+
 @task
 @roles('class-licensify-frontend', 'class-licensify-backend')
 def greplogs(pattern, context=100):
@@ -8,4 +9,3 @@ def greplogs(pattern, context=100):
     run(grep_cmd.format(app='licensify',       pattern=pattern, context=context))
     run(grep_cmd.format(app='licensify-admin', pattern=pattern, context=context))
     run(grep_cmd.format(app='licensify-feed',  pattern=pattern, context=context))
-

--- a/locksmith.py
+++ b/locksmith.py
@@ -6,9 +6,11 @@ import util
 etcd_cluster = 'http://etcd-1.management:4001,http://etcd-2.management:4001,http://etcd-3.management:4001'
 locksmithctl = '/usr/bin/locksmithctl'
 
+
 def check_locksmithctl():
     if not fabric.contrib.files.exists(locksmithctl):
         error('locksmithctl is not installed. Perhaps unattended_reboots are disabled?')
+
 
 @task
 def status():
@@ -16,6 +18,7 @@ def status():
     util.use_random_host('class-etcd')
     check_locksmithctl()
     run("{0} -endpoint='{1}' status".format(locksmithctl, etcd_cluster))
+
 
 @task
 def unlock(machine_name):

--- a/logstream.py
+++ b/logstream.py
@@ -1,7 +1,7 @@
 from fabric.api import *
 
+
 @task
 def restart_all():
     """Restart all the logstreams on a machine"""
     sudo("for logstream in `ls /etc/init/logstream*`; do BASE=`basename $logstream .conf`; service $BASE restart; done")
-

--- a/mainstream_slugs.py
+++ b/mainstream_slugs.py
@@ -1,6 +1,7 @@
 from fabric.api import *
 import util
 
+
 @task
 def change(old_url, new_url):
     """Change a mainstream slug. Usage: fab preview mainstream_slugs.change:old_slug=/old-slug,new_slug=/new-slug"""

--- a/mapit.py
+++ b/mapit.py
@@ -5,12 +5,13 @@ import app
 import nginx
 import puppet
 
+
 @task
 def update_database():
     """Update a Mapit database using a new database dump"""
 
     if len(env.hosts) > 1:
-      exit('This command should only be run on one Mapit machine at a time')
+        exit('This command should only be run on one Mapit machine at a time')
 
     execute(nginx.gracefulstop)
     execute(app.stop, 'mapit')
@@ -19,7 +20,7 @@ def update_database():
     sudo('rm /data/vhost/mapit/data/mapit.sql.gz')
 
     with settings(sudo_user='postgres'):
-      sudo("psql -c 'DROP DATABASE mapit;'")
+        sudo("psql -c 'DROP DATABASE mapit;'")
 
     execute(puppet.agent, '--test')
 

--- a/mysql.py
+++ b/mysql.py
@@ -98,8 +98,8 @@ def reset_slave():
     run_mysql_command("RESET SLAVE;")
 
     # Repoint log file and position to last known values
-    run_mysql_command("CHANGE MASTER TO MASTER_LOG_FILE='{}', MASTER_LOG_POS={};" \
-            .format(master_log_file, master_log_pos))
+    run_mysql_command("CHANGE MASTER TO MASTER_LOG_FILE='{}', MASTER_LOG_POS={};"
+                      .format(master_log_file, master_log_pos))
     run_mysql_command("START SLAVE;")
 
     with hide('everything'):
@@ -107,8 +107,8 @@ def reset_slave():
 
     # Compare as a string to ensure we got a non-nil value from MySQL
     if seconds_behind_master != '0':
-        abort("Slave is still behind master by {} seconds; run mysql.slave_status to check status" \
-                .format(seconds_behind_master))
+        abort("Slave is still behind master by {} seconds; run mysql.slave_status to check status"
+              .format(seconds_behind_master))
 
 
 @task

--- a/nagios.py
+++ b/nagios.py
@@ -24,7 +24,7 @@ def _monitoring_hostname(host):
 
 @task
 @hosts(['alert.cluster'])
-def schedule_downtime(host,minutes='20'):
+def schedule_downtime(host, minutes='20'):
     """Schedules downtime for a host in nagios; default for 20 minutes"""
 
     # get timestamp from monitoring server to avoid clock skew issues.

--- a/nagios.py
+++ b/nagios.py
@@ -1,7 +1,5 @@
 from urllib import quote_plus
-from StringIO import StringIO
 import json
-import string
 
 from fabric.api import *
 

--- a/nginx.py
+++ b/nginx.py
@@ -4,6 +4,7 @@ import puppet
 
 maintenance_config = '/etc/nginx/includes/maintenance.conf'
 
+
 @task
 def enable_maintenance():
     """Enables a maintenance page and serves a 503"""
@@ -13,6 +14,7 @@ def enable_maintenance():
     puppet.disable("Maintenance mode enabled")
     sudo("echo 'set $maintenance 1;' > {0}".format(maintenance_config))
     sudo('service nginx reload')
+
 
 @task
 def disable_maintenance():
@@ -24,6 +26,7 @@ def disable_maintenance():
     sudo('service nginx reload')
     puppet.enable()
 
+
 def gracefulstop(wait=True):
     """Gracefully shutdown Nginx by finishing any in-flight requests"""
     sudo('nginx -s quit')
@@ -32,21 +35,25 @@ def gracefulstop(wait=True):
         # Poll for Nginx, until it's no longer running.
         run('while pgrep nginx >/dev/null; do echo "Waiting for Nginx to exit.."; sleep 1; done')
 
+
 @task
 def gracefulrestart():
     """Gracefully shutdown and start Nginx (not reload)"""
     gracefulstop()
     start()
 
+
 @task
 def kill():
     """Shut down Nginx immediately without waiting for it to finish running"""
     sudo('service nginx stop')
 
+
 @task
 def start():
     """Start up Nginx on a machine"""
     sudo('service nginx start')
+
 
 @task
 def force_restart():

--- a/ntp.py
+++ b/ntp.py
@@ -1,15 +1,17 @@
 from fabric.api import *
 
+
 @task
 def status():
     """Report the VM's NTP status."""
     run("ntpq -p")
     run("/usr/lib/nagios/plugins/check_ntp_time -q -H ntp.ubuntu.com -w 2 -c 3", warn_only=True)
 
+
 @task
 def resync():
     """Forcibly resynchronise the VM's NTP clock.
-    
+
     If a VM's clock manages to get sufficiently out of sync, ntp will give up,
     forcing a manual intervention.
     """

--- a/performanceplatform.py
+++ b/performanceplatform.py
@@ -61,8 +61,7 @@ def get_command(query_path, query):
 
     pp_collector = './venv/bin/pp-collector'
     credentials_path = './config/credentials/{}.json'.format(credentials)
-    token_path = './config/tokens/{}.json'.format(
-        query['token'])
+    token_path = './config/tokens/{}.json'.format(query['token'])
     platform_path = './config/performanceplatform.json'
 
     return '{} -q {} -c {} -t {} -b {} --console-logging'.format(

--- a/performanceplatform.py
+++ b/performanceplatform.py
@@ -62,7 +62,7 @@ def get_command(query_path, query):
     pp_collector = './venv/bin/pp-collector'
     credentials_path = './config/credentials/{}.json'.format(credentials)
     token_path = './config/tokens/{}.json'.format(
-    query['token'])
+        query['token'])
     platform_path = './config/performanceplatform.json'
 
     return '{} -q {} -c {} -t {} -b {} --console-logging'.format(

--- a/postgresql.py
+++ b/postgresql.py
@@ -1,5 +1,4 @@
-from fabric.api import task, sudo, env, settings, run
-from fabric.utils import abort
+from fabric.api import task, settings, run
 
 @task
 def sync(database, dest_machine):

--- a/postgresql.py
+++ b/postgresql.py
@@ -1,5 +1,6 @@
 from fabric.api import task, settings, run
 
+
 @task
 def sync(database, dest_machine):
     # the agent forwarding is required for the ssh command to the destination

--- a/puppet.py
+++ b/puppet.py
@@ -1,22 +1,27 @@
 from fabric.api import *
 
+
 def puppet(*args):
     sudo('govuk_puppet %s' % ' '.join(args))
+
 
 @task(default=True)
 def agent(*args):
     """Run puppet agent"""
     puppet(*args)
 
+
 @task
 def disable(reason):
     """Disable puppet runs. Requires a reason as a string arg"""
     puppet('--disable "{0} (by {1})"'.format(reason, env.user))
 
+
 @task
 def enable():
     """Enable puppet runs"""
     puppet('--enable')
+
 
 @task
 def check_disabled():
@@ -26,10 +31,12 @@ def check_disabled():
     with hide('running'):
         sudo('test -f {0} && echo DISABLED || echo ENABLED'.format(lockfile))
 
+
 @task
 def dryrun(*args):
     """Run puppet agent but make no changes to the system"""
     puppet('--noop', *args)
+
 
 @task
 @hosts('puppetmaster-1.management')

--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -2,6 +2,7 @@ from fabric.api import *
 from time import sleep
 import re
 
+
 @task
 @roles('class-rabbitmq')
 def status():

--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+flake8

--- a/rkhunter.py
+++ b/rkhunter.py
@@ -1,9 +1,11 @@
 from fabric.api import *
 
+
 @task(default=True)
 def check(*args):
     """Run rkhunter on the machine"""
     sudo('/etc/cron.daily/rkhunter-passive-check')
+
 
 @task
 def propupdate(*args):

--- a/search.py
+++ b/search.py
@@ -3,17 +3,17 @@ from fabric.api import *
 import util
 
 SEARCHABLE_APPS = {
-    'calendars':             ('frontend', ['panopticon:register']),
-    'designprinciples':      ('frontend', ['rummager:index']), # Includes the service-manual. Note: not included in gov.uk/search
-    'frontend':              ('frontend', ['rummager:index']),
-    'licencefinder':         ('frontend', ['panopticon:register']),
-    'businesssupportfinder': ('frontend', ['panopticon:register']),
-    'publisher':             ('backend',  ['panopticon:register']),
-    'recommended-links':     ('backend',  ['rummager:index']),
-    'smartanswers':          ('frontend', ['panopticon:register']),
-    'tariff':                ('frontend', ['panopticon:register']),
-    'travel-advice-publisher':('backend', ['panopticon:register', 'panopticon:reregister_editions']),
-    'whitehall':             ('whitehall_backend',  ['rummager:index']),
+    'calendars':               ('frontend',          ['panopticon:register']),
+    'designprinciples':        ('frontend',          ['rummager:index']), # Includes the service-manual. Note: not included in gov.uk/search
+    'frontend':                ('frontend',          ['rummager:index']),
+    'licencefinder':           ('frontend',          ['panopticon:register']),
+    'businesssupportfinder':   ('frontend',          ['panopticon:register']),
+    'publisher':               ('backend',           ['panopticon:register']),
+    'recommended-links':       ('backend',           ['rummager:index']),
+    'smartanswers':            ('frontend',          ['panopticon:register']),
+    'tariff':                  ('frontend',          ['panopticon:register']),
+    'travel-advice-publisher': ('backend',           ['panopticon:register', 'panopticon:reregister_editions']),
+    'whitehall':               ('whitehall_backend', ['rummager:index']),
 }
 
 

--- a/search.py
+++ b/search.py
@@ -16,12 +16,14 @@ SEARCHABLE_APPS = {
     'whitehall':             ('whitehall_backend',  ['rummager:index']),
 }
 
+
 @task
 def list():
     """List known searchable applications"""
 
     for app in sorted(SEARCHABLE_APPS.keys()):
         puts(app)
+
 
 @task
 def reindex(app=None):

--- a/search.py
+++ b/search.py
@@ -4,7 +4,10 @@ import util
 
 SEARCHABLE_APPS = {
     'calendars':               ('frontend',          ['panopticon:register']),
-    'designprinciples':        ('frontend',          ['rummager:index']), # Includes the service-manual. Note: not included in gov.uk/search
+
+    # Includes the service-manual. Note: not included in gov.uk/search
+    'designprinciples':        ('frontend',          ['rummager:index']),
+
     'frontend':                ('frontend',          ['rummager:index']),
     'licencefinder':           ('frontend',          ['panopticon:register']),
     'businesssupportfinder':   ('frontend',          ['panopticon:register']),

--- a/statsd.py
+++ b/statsd.py
@@ -14,5 +14,5 @@ def create_counter(name):
     Read about carbon-aggregator counters before using this task:
     https://github.gds/pages/gds/opsmanual/2nd-line/nagios.html#nginx-5xx-rate-too-high-for-many-apps-boxes"""
     # remove an initial stats. prefix if present
-    name = re.sub(r"^stats\.","",name)
+    name = re.sub(r"^stats\.", "", name)
     run("echo -n '%s:0|c' > /dev/udp/localhost/8125" % name)

--- a/topic_change.py
+++ b/topic_change.py
@@ -69,6 +69,7 @@ def move_in_panopticon(source_topic, destination_topic):
     """
     do_move_in_panopticon(source_topic, destination_topic)
 
+
 def do_move_in_panopticon(source_topic, destination_topic):
     util.use_random_host('class-backend')
     print("\nRetagging content on %s" % (api.env.host_string,))
@@ -82,6 +83,7 @@ def delete_topic(old_topic):
 
     """
     do_delete_topic(old_topic)
+
 
 def do_delete_topic(old_topic):
     util.use_random_host('class-backend')
@@ -173,7 +175,7 @@ def prepare_whitehall_csv(output_directory, source_topic, destination_topic):
               SOURCE=source_topic,
               DESTINATION=destination_topic,
               CSV_LOCATION=remote_path,
-    )
+              )
     api.get(remote_path, os.path.join(output_directory, filename))
     api.sudo("rm '%s'" % (remote_path,), user="deploy")
 

--- a/vm.py
+++ b/vm.py
@@ -4,25 +4,30 @@ import re
 
 import nagios
 
+
 @task
 def uptime():
     """Show uptime and load"""
     run('uptime')
+
 
 @task
 def free():
     """Show memory stats"""
     run('free')
 
+
 @task
 def disk():
     """Show disk usage"""
     run('df -kh')
 
+
 @task
 def os_version():
     """Show operating system"""
     run('facter lsbdistcodename lsbdistdescription operatingsystem operatingsystemrelease')
+
 
 @task
 def deprecated_library(name):
@@ -38,11 +43,13 @@ def deprecated_library(name):
     """
     sudo("lsof -d DEL | awk '$8 ~ /{0}/'".format(re.escape(name)))
 
+
 @task
 def stopped_jobs():
     """Find stopped govuk application jobs"""
     with hide('running'):
         run('grep -l govuk_spinup /etc/init/*.conf | xargs -n1 basename | while read line; do sudo status "${line%%.conf}"; done | grep stop || :')
+
 
 @task
 def bodge_unicorn(name):
@@ -64,9 +71,11 @@ def bodge_unicorn(name):
         sudo("kill -9 %s" % pid)
     sudo("start '{0}' || restart '{0}'".format(name))
 
+
 @task
 def reload_unicorn(name):
     error("task deprecated by 'app.reload'")
+
 
 def reboot_required():
     """
@@ -76,66 +85,71 @@ def reboot_required():
     result = run("/usr/local/bin/check_reboot_required 30 0", warn_only=True)
     return (not result.succeeded)
 
+
 @task
 def reboot():
-  """Schedule a host for downtime in nagios and reboot (if required)
+    """Schedule a host for downtime in nagios and reboot (if required)
 
-  Usage:
-  fab production -H frontend-1.frontend.production vm.reboot
-  """
-  if reboot_required():
-      # we need to ensure we only execute this task on the current
-      # host we're operating on, not every host in env.hosts
-      execute(force_reboot, hosts=[env['host_string']])
+    Usage:
+    fab production -H frontend-1.frontend.production vm.reboot
+    """
+    if reboot_required():
+        # we need to ensure we only execute this task on the current
+        # host we're operating on, not every host in env.hosts
+        execute(force_reboot, hosts=[env['host_string']])
+
 
 @task
 def force_reboot():
-  """Schedule a host for downtime in nagios and force reboot (even if not required)"""
-  execute(nagios.schedule_downtime, env['host_string'])
-  run("sudo shutdown -r now")
+    """Schedule a host for downtime in nagios and force reboot (even if not required)"""
+    execute(nagios.schedule_downtime, env['host_string'])
+    run("sudo shutdown -r now")
+
 
 @task
 def poweroff():
-  """Schedule a host for downtime in nagios and shutdown the VM
+    """Schedule a host for downtime in nagios and shutdown the VM
 
-  Usage:
-  fab production -H frontend-1.frontend.production vm.poweroff
-  """
-  execute(nagios.schedule_downtime, env['host_string'])
-  run("sudo poweroff")
+    Usage:
+    fab production -H frontend-1.frontend.production vm.poweroff
+    """
+    execute(nagios.schedule_downtime, env['host_string'])
+    run("sudo poweroff")
+
 
 @task
 @hosts('puppetmaster-1.management')
 def host_key(hostname):
-  """
-  Check the SSH host key of a machine. This task runs on the Puppetmaster because
-  it's the only machine that knows about all host keys.
+    """
+    Check the SSH host key of a machine. This task runs on the Puppetmaster because
+    it's the only machine that knows about all host keys.
 
-  Usage:
-  fab production vm.host_key:backend-1.backend
-  """
-  with hide('running', 'stdout'):
-    ssh_key = run("grep {0} /etc/ssh/ssh_known_hosts | head -1".format(hostname))
+    Usage:
+    fab production vm.host_key:backend-1.backend
+    """
+    with hide('running', 'stdout'):
+        ssh_key = run("grep {0} /etc/ssh/ssh_known_hosts | head -1".format(hostname))
 
-  if ssh_key == '':
-    print 'Machine {0} not found in ssh_known_hosts file'.format(hostname)
-  else:
-    with hide('running'):
-      run("ssh-keygen -l -f /dev/stdin <<< '{0}'".format(ssh_key))
+    if ssh_key == '':
+        print 'Machine {0} not found in ssh_known_hosts file'.format(hostname)
+    else:
+        with hide('running'):
+            run("ssh-keygen -l -f /dev/stdin <<< '{0}'".format(ssh_key))
+
 
 @task
 @parallel(pool_size=5)
 def connected_users():
-  """
-  Output a list of users who are logged in to a machine
-  """
+    """
+    Output a list of users who are logged in to a machine
+    """
 
-  with hide('running', 'stdout'):
-    username = run('whoami')
-    users = run('who | grep -v {0} || true'.format(username))
+    with hide('running', 'stdout'):
+        username = run('whoami')
+        users = run('who | grep -v {0} || true'.format(username))
 
-  if users:
-    print 'There are users connected to {0}:'.format(env.host_string)
-    for user in users.split("\n"):
-      print '  - {0}'.format(user.split(' ')[0])
-    print "\n"
+    if users:
+        print 'There are users connected to {0}:'.format(env.host_string)
+        for user in users.split("\n"):
+            print '  - {0}'.format(user.split(' ')[0])
+        print "\n"


### PR DESCRIPTION
Add a `.travis.yml` file to have Travis CI run flake8 whenever a pull
request is raised.

Travis will run `make test`, which in turn will run `flake8`, which
wraps the PyFlakes syntax checker and pep8 style checker:
https://pypi.python.org/pypi/flake8

We test `fabfile.py` separately to all other files because it imports
the Fabfile subcommand modules, which causes flakes8 to report:

    fabfile.py:16:1: F401 'puppet' imported but unused
    fabfile.py:19:1: F401 'app' imported but unused
    fabfile.py:20:1: F401 'apt' imported but unused
    fabfile.py:21:1: F401 'cache' imported but unused
    fabfile.py:22:1: F401 'campaigns' imported but unused
    fabfile.py:23:1: F401 'cdn' imported but unused
    fabfile.py:24:1: F401 'elasticsearch' imported but unused
    fabfile.py:25:1: F401 'incident' imported but unused
    fabfile.py:26:1: F401 'licensify' imported but unused
    fabfile.py:27:1: F401 'locksmith' imported but unused
    fabfile.py:28:1: F401 'logstream' imported but unused
    fabfile.py:29:1: F401 'mongo' imported but unused
    fabfile.py:30:1: F401 'mainstream_slugs' imported but unused
    fabfile.py:31:1: F401 'mapit' imported but unused
    fabfile.py:32:1: F401 'mysql' imported but unused
    fabfile.py:33:1: F401 'nagios' imported but unused
    fabfile.py:34:1: F401 'nginx' imported but unused
    fabfile.py:35:1: F401 'ntp' imported but unused
    fabfile.py:36:1: F401 'performanceplatform' imported but unused
    fabfile.py:37:1: F401 'postgresql' imported but unused
    fabfile.py:38:1: F401 'rabbitmq' imported but unused
    fabfile.py:39:1: F401 'rkhunter' imported but unused
    fabfile.py:40:1: F401 'search' imported but unused
    fabfile.py:41:1: F401 'statsd' imported but unused
    fabfile.py:42:1: F401 'topic_change' imported but unused
    fabfile.py:43:1: F401 'vm' imported but unused
    fabfile.py:44:1: F401 'whitehall' imported but unused

So we run flake8 separately against `fabfile.py`, ignoring errors of
type `F401` ("imported but not used").

For all other files, we ignore:

  - `E501` "line too long" errors, since modern terminals are capable of
    displaying very long lines and enforcing shorter lines using tests
    can hamper readability

  - `F403` "'from module import *' used; unable to detect undefined
    names", which commonly occurs in our code but seems to be spurious;
    I'm not familiar enough with Python to judge

* * *

__I'm not very familiar with Python or autopep8 and have only performed minimal testing on these changes; I would appreciate feedback from someone with more experience with autopep8.__