### PR TITLE
Death of a notable person banner should be set on static

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -81,10 +81,7 @@ def deploy_emergency_banner():
     """Deploy an emergency banner to GOV.UK"""
     execute(set_context)
     for application in APPLICATIONS:
-        # Black banners are only placed on the homepage i.e.'frontend'.
-        # Don't deploy a black banner to the static application.
-        if not (env.campaign_class == 'black' and application == 'static'):
-            deploy_banner(application)
+        deploy_banner(application)
 
 @task
 @roles('class-frontend')


### PR DESCRIPTION
As of https://github.com/alphagov/static/pull/658, black campaign
banners can be set on all GOV.UK pages, not just the front page. This
removes the condition that wouldn’t upload the banner to the static
application.

https://trello.com/c/LQBRJ1eI/137-ensure-black-campaign-banner-appears-on-same-pages-as-emergency-banners