### PR TITLE
Fix more info link in banner

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -45,7 +45,7 @@ def template(app):
     elif app == 'static':
         template = Template("""<p>{{ heading|e }}<br />
     {{ extra_info|e }}</p>
-  <a href="#" class="right">{{ more_info|e }}</a>""")
+  <a href="{{ more_info|e }}" class="right">More information</a>""")
 
     env['template_contents'] = template.render(env.context)
 


### PR DESCRIPTION
During a national emergency when the country ran out of coffee, we
discovered that the banner in static didn't have a `href` on the more
info link. This commit fixes that in the template that is wrote to
static.