### PR TITLE
Restart memcached when updating MapIt to clear its cache

### DIFF
--- a/mapit.py
+++ b/mapit.py
@@ -18,6 +18,8 @@ def update_database():
     # Stop mapit and collectd which are using the Mapit database so that we can drop it
     execute(app.stop, 'mapit')
     sudo('service collectd stop')
+    # Make sure that cached mapit responses are cleared when the database is updated
+    sudo('service memcached restart')
 
     # Delete the old sql dump to force a new download
     sudo('rm /data/vhost/mapit/data/mapit.sql.gz')


### PR DESCRIPTION
MapIt uses memcached and we've seen cached responses being returned for
several days after updating the database, even though we have
`CACHE_MIDDLEWARE_SECONDS = 86400` (1 day). Restarting memcached will clear the
cache so that we get updated responses as soon as the database has been
updated.