### PR TITLE
Remove double sudo

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -21,7 +21,7 @@ def ban_all():
 
     See: https://www.varnish-cache.org/docs/3.0/tutorial/purging.html
     """
-    sdo("sudo varnishadm 'ban req.url ~ .'")
+    sdo("varnishadm 'ban req.url ~ .'")
 
 
 @task


### PR DESCRIPTION
This command already runs under `sudo` (`sdo` invokes `sudo`).