### PR TITLE
Use `sudo` rather than `sdo` in ban_all

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -21,7 +21,7 @@ def ban_all():
 
     See: https://www.varnish-cache.org/docs/3.0/tutorial/purging.html
     """
-    sdo("sudo varnishadm 'ban req.url ~ .'")
+    sudo("sudo varnishadm 'ban req.url ~ .'")
 
 
 @task


### PR DESCRIPTION
To prevent this error:

    NameError: global name 'sdo' is not defined