### PR TITLE
Fix cache.ban_all

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -21,7 +21,7 @@ def ban_all():
 
     See: https://www.varnish-cache.org/docs/3.0/tutorial/purging.html
     """
-    sudo("sudo varnishadm 'ban req.url ~ .'")
+    sudo("varnishadm 'ban req.url ~ .'")
 
 
 @task

--- a/cache.py
+++ b/cache.py
@@ -21,7 +21,7 @@ def ban_all():
 
     See: https://www.varnish-cache.org/docs/3.0/tutorial/purging.html
     """
-    sdo("sudo varnishadm 'ban req.url ~ .'")
+    sudo("sudo varnishadm 'ban req.url ~ .'")
 
 
 @task


### PR DESCRIPTION
Use `sudo` rather than `sdo` in ban_all to prevent this error:

    NameError: global name 'sdo' is not defined

Also, remove an unnecessary call to `sudo` in the command string.