### PR TITLE
Add a task to find which machines host an app

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -290,6 +290,14 @@ def puppet_class(*class_names):
 
 
 @task
+@runs_once
+def application(app_name):
+    """Select all machines which host a given application"""
+    class_name = 'govuk::apps::{}'.format(app_name.replace('-', '_'))
+    puppet_class(class_name)
+
+
+@task
 @hosts('localhost')
 def node_type(node_name):
     """Select all machines of a given node type"""


### PR DESCRIPTION
Add a convenience task that allows you to target machines that host a
given GOV.UK application.

Example:

    fab preview application:whitehall hosts
    [whitehall-backend-2.backend.production] Executing task 'hosts'
    whitehall-backend-1.backend.production
    whitehall-backend-2.backend.production
    whitehall-frontend-1.frontend.production
    whitehall-frontend-2.frontend.production
    Disconnecting from jumpbox.preview.alphagov.co.uk... done.

    Done.