### PR TITLE
[#108209890] Add new Integration environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ You can view a list of the available tasks:
 
 And execute against an environment and set of hosts like so:
 
-    $ fab preview all hosts
+    $ fab integration all hosts
     ...
-    $ fab preview class:frontend do:'uname -a'
-    $ fab preview class:cache,bouncer do:uptime
+    $ fab integration class:frontend do:'uname -a'
+    $ fab integration class:cache,bouncer do:uptime
     ...
 
 ### Targetting groups of machines
@@ -45,17 +45,17 @@ Fabric tasks can be run on groups of machines in a variety of different ways.
 by puppet class
 
     # target all machines that have the 'govuk::safe_to_reboot::yes' class
-    $ fab preview puppet_class:govuk::safe_to_reboot::yes do:'uname -a'
+    $ fab integration puppet_class:govuk::safe_to_reboot::yes do:'uname -a'
 
 by numeric machine suffix
 
     # target all machines that end in '2'
-    $ fab preview numbered:2 do:'uname -a'
+    $ fab integration numbered:2 do:'uname -a'
 
 by node type (as defined in puppet)
 
     # target all 'frontend' machines
-    $ fab preview node_type:frontend do:'uname -a'
+    $ fab integration node_type:frontend do:'uname -a'
 
 by the node name
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -104,8 +104,8 @@ class RoleFetcher(object):
                 continue
 
             # Don't refer to foo.bar.production, as it's confusing when doing
-            # things in preview or staging. Refer to the machines exclusively by
-            # short name.
+            # things in integration or staging. Refer to the machines
+            # exclusively by short name.
             short_host = '{0}.{1}'.format(name, vdc)
 
             cls = name.rstrip('-1234567890').replace('-', '_')

--- a/fabfile.py
+++ b/fabfile.py
@@ -250,6 +250,14 @@ def staging():
 
 
 @task
+def integration():
+    """Select integration environment"""
+    env['environment'] = 'integration'
+    _set_gateway('integration.publishing.service.gov.uk')
+
+
+# FIXME: Remove once Preview environment is deleted
+@task
 def preview():
     """Select preview environment"""
     env['environment'] = 'preview'

--- a/mainstream_slugs.py
+++ b/mainstream_slugs.py
@@ -4,7 +4,7 @@ import util
 
 @task
 def change(old_url, new_url):
-    """Change a mainstream slug. Usage: fab preview mainstream_slugs.change:old_slug=/old-slug,new_slug=/new-slug"""
+    """Change a mainstream slug. Usage: fab integration mainstream_slugs.change:old_slug=/old-slug,new_slug=/new-slug"""
     util.use_random_host('class-backend')
     util.rake('panopticon', 'delete_mainstream_slug_from_search', old_url)
     util.rake('publisher', 'update_mainstream_slug', old_url, new_url)

--- a/nagios.py
+++ b/nagios.py
@@ -14,12 +14,12 @@ def submit_nagios_cmd(command):
 
 def _monitoring_hostname(host):
     """Returns the canonical name (according to our monitoring) for a host"""
-    if env['environment'] == 'preview':
-        return "%s.production" % host
-    elif env['environment'] == 'staging':
-        return "{0}.staging.publishing.service.gov.uk".format(host)
-    else:
+    if env['environment'] == 'production':
         return "{0}.publishing.service.gov.uk".format(host)
+    elif env['environment'] == 'preview': # FIXME: Remove once Preview is deleted
+        return "%s.production" % host
+    else:
+        return "{0}.{1}.publishing.service.gov.uk".format(host, env['environment'])
 
 
 @task

--- a/vm.py
+++ b/vm.py
@@ -62,11 +62,11 @@ def bodge_unicorn(name):
 
     e.g. To kill off and restart contentapi on backend-1 in Preview:
 
-      fab preview -H backend-1.backend vm.bodge_unicorn:contentapi
+      fab integration -H backend-1.backend vm.bodge_unicorn:contentapi
 
     ...or on all backend hosts in Preview:
 
-      fab preview class:backend vm.bodge_unicorn:contentapi
+      fab integration class:backend vm.bodge_unicorn:contentapi
 
     Yes. This is a bodge. Sorry.
     """


### PR DESCRIPTION
The new 'Integration' environment will soon replace 'Preview'; add
support for it so that we can start running Fabric scripts against it.

I'd added a FIXME to remove the code for Preview once we've migrated
away from that environment.