### PR TITLE
Show the amount of files rabbitmq is holding open

### DIFF
--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -67,3 +67,9 @@ def safe_reboot():
 
     execute(vm.reboot, hosts=[env['host_string']])
     sleep(10)
+
+@task
+@roles('class-rabbitmq')
+def open_fd():
+    """Show the number of open files rabbitmq is holding"""
+    sudo('lsof -a -p $(pidof beam.smp) |wc -l')


### PR DESCRIPTION
This is related to a story in 2ndline where rabbitmq stopped accepting new connections due to the following alert:

```
=WARNING REPORT==== 16-Nov-2015::10:47:53 ===
file descriptor limit alarm set.

********************************************************************
*** New connections will not be accepted until this alarm clears ***
********************************************************************
```

This is a fabric task which counts the number of open files by the rabbitmq process.