### PR TITLE
New mapit db update scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
 test:
-	@flake8 . --exclude fabfile.py --ignore=E241,E501, \
-	  F403 # FIXME: Fix these errors and stop ignoring them
+	@flake8 . --exclude fabfile.py --ignore=E241,E501,F403 # FIXME: Fix these errors and stop ignoring them
 	@flake8 fabfile.py --ignore=E241,E501,F401

--- a/mapit.py
+++ b/mapit.py
@@ -39,10 +39,14 @@ def check_database_upgrade():
 
     sudo("awk '$9==200 {print \"http://localhost\" $7}' /var/log/nginx/mapit.access.log.1 > mapit-200s")
     sudo("awk '$9==404 {print \"http://localhost\" $7}' /var/log/nginx/mapit.access.log.1 > mapit-404s")
+    sudo("awk '$9==302 {print \"http://localhost\" $7}' /var/log/nginx/mapit.access.log.1 > mapit-302s")
 
     print "Replaying Mapit 200s. Ensure that they are all still 200s."
+    print "NOTE: Some 404s may result if internal ids have changed because /area/<code> will redirect to /area/<internal-id> - this should be a low number and for /area/ urls only"
     run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-200s | sort | uniq -c')
     print "Replaying Mapit 404s. Ensure that they are all either 200s or 404s."
     run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-404s | sort | uniq -c')
+    print "Replaying Mapit 302s. Ensure that they are all still 302s. (these should be the /area/<code> redirects mentioned above)"
+    run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-404s | sort | uniq -c')
 
-    sudo('rm ~/mapit-200s ~/mapit-404s')
+    sudo('rm ~/mapit-200s ~/mapit-404s ~/mapit-302s')

--- a/mapit.py
+++ b/mapit.py
@@ -45,6 +45,9 @@ def update_database_via_app():
 
 
 def _stop_mapit_services():
+    # Stop puppet so that any scheduled runs don't happen while we are doing
+    # our work
+    execute(puppet.disable, 'Updating mapit database which requires stopping some services we would not want a scheduled puppet run to restart before we were done')
     # Stop NginX so that no requests reach this machine
     execute(nginx.gracefulstop)
     # Stop mapit and collectd which are using the Mapit database so that we can drop it
@@ -55,6 +58,7 @@ def _stop_mapit_services():
 
 
 def _restart_mapit_services():
+    execute(puppet.enable)
     # Run puppet, which will restart the services which were stopped earlier.
     # On old mapit servers this will also download and recreate the db if we've
     # deleted them.

--- a/mysql.py
+++ b/mysql.py
@@ -89,7 +89,7 @@ def replicate_slave_from_master(master):
     with hide('running', 'stdout'):
         database_file_size = run("stat --format='%s' dump.sql")
 
-    print('Importing MySQL database which is {0}GB, this might take a while...'.format(round(int(database_file_size) / (1024*1024*1024*1.0), 1)))
+    print('Importing MySQL database which is {0}GB, this might take a while...'.format(round(int(database_file_size) / (1024 * 1024 * 1024 * 1.0), 1)))
     run('sudo -i mysql -uroot < dump.sql')
 
     run('rm dump.sql')


### PR DESCRIPTION
Update fabric scripts to allow us to update the db of new mapit servers that live on api instead of backend namespace.

New servers no longer use puppet to manage fetching the database dump and populating the db, they rely on a script in the application.  The script lives in https://github.com/alphagov/mapit/pull/8 so this PR shouldn't be merged until that is, or we want to test it on preview.  We've retained the old task because we'll still want it available for the backend servers in production, until we're ready to promote the new mapit stuff all the way to production.  At which point we'll want a new PR to remove the old way of doing things.

There's more details about the task in the commits and the other PRs.