### PR TITLE
Clea core layout cache

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -66,7 +66,7 @@ def clear_static_generated_templates():
     This function clears the public/template directory to force it to
     be regenerated to include the emergency campaign.
     """
-    for template in ('wrapper.html.erb', 'header_footer_only.html.erb'):
+    for template in ('wrapper.html.erb', 'header_footer_only.html.erb', 'core_layout.html.erb'):
         sudo('rm /var/apps/static/public/templates/{}'.format(template))
 
 

--- a/campaigns.py
+++ b/campaigns.py
@@ -52,16 +52,15 @@ def template(app):
 
 def clear_static_generated_templates():
     """
-    Our various frontend applications use the wrapper.html.erb and
-    header_footer_only.html.erb templates. They get these templates
-    using the Slimmer gem. And this gem fetches these templates from
-    the static application, located using the ASSET_ROOT.
+    Our various frontend applications use the wrapper.html.erb,
+    header_footer_only.html.erb and core_layout.html.erb layout templates.
+    They get these templates using the Slimmer gem, which fetches
+    these templates from the static application, located using ASSET_ROOT.
 
-    When static is deployed there are no generated wrapper.html.erb or
-    header_footer_only.html.erb templates. At the first request of
-    either of these, the application will generate the template. The
-    template will be placed in the public/template directory. From
-    that point on, the templates are served by nginx.
+    When static is deployed there are no generated layout templates
+    on static At the first request to one these, static will generate
+    the template. The template will be placed in the public/template
+    directory. From that point on, the templates are served by nginx.
 
     This function clears the public/template directory to force it to
     be regenerated to include the emergency campaign.


### PR DESCRIPTION
As part of emergency publishing we update static layout templates, which are page cached (to public, from where they're then served by `nginx`, not rails).

We manually clear two of the layout files, but not `core_layout` which was more recently introduced.

This is a pretty short term fix, and will break again if we add or rename a layout.

A medium term solution is moving the uncaching logic to a static rake task, so that lives in the same place as the templates, and is less likely to fall out of sync.

A longer term solution is using ESI, and side-stepping caching entirely.

As we've not gone for a medium or long term solution yet, this fixes the issue causing apps to not update after a emergency publishing/unpublishing

Also updated the docs a bit, to reflect the 3 layouts, and try and make the whole thing a bit
more readable.