### PR TITLE
More emergency publishing improvements

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -78,9 +78,9 @@ def deploy_banner(application):
     content = env['template_contents']
     put(StringIO.StringIO(content), remote_filename, use_sudo=True, mirror_local_mode=True)
     sudo('chown deploy:deploy %s' % remote_filename)
+    execute(app.reload, application)
     if application == 'static':
         clear_static_generated_templates()
-    execute(app.reload, application)
 
 
 def remove_banner(application):
@@ -92,9 +92,9 @@ def remove_banner(application):
     for remote_filename in remote_filenames:
         put(StringIO.StringIO(content), remote_filename, use_sudo=True, mirror_local_mode=True)
         sudo('chown deploy:deploy %s' % remote_filename)
+    execute(app.reload, application)
     if application == 'static':
         clear_static_generated_templates()
-    execute(app.reload, application)
 
 
 @task

--- a/campaigns.py
+++ b/campaigns.py
@@ -78,7 +78,7 @@ def deploy_banner(application):
     content = env['template_contents']
     put(StringIO.StringIO(content), remote_filename, use_sudo=True, mirror_local_mode=True)
     sudo('chown deploy:deploy %s' % remote_filename)
-    execute(app.reload, application)
+    execute(app.restart, application)
     if application == 'static':
         clear_static_generated_templates()
 
@@ -92,7 +92,7 @@ def remove_banner(application):
     for remote_filename in remote_filenames:
         put(StringIO.StringIO(content), remote_filename, use_sudo=True, mirror_local_mode=True)
         sudo('chown deploy:deploy %s' % remote_filename)
-    execute(app.reload, application)
+    execute(app.restart, application)
     if application == 'static':
         clear_static_generated_templates()
 


### PR DESCRIPTION
Reloading applications uses unicornherder to start new processes and give them time to warm up before killing the old ones.

However it introduces a race condition in the generation of static's file cache where we have both old and new workers running.

When we're publishing an emergency notification on GOV.UK it's simpler to just do a hard restart of the application. This might cause requests to be dropped for a very short amount of time (but no more than a normal application deploy would).

/cc @dsingleton