### PR TITLE
Make Puppet noisier by default

### DIFF
--- a/incident.py
+++ b/incident.py
@@ -19,5 +19,5 @@ def fail_to_mirror():
 def recover_origin():
     """Recovers GOV.UK to serve from origin after incident.fail_to_mirror has been invoked"""
     puppet.enable()
-    puppet.agent("--test")
+    puppet.agent()
     print("Puppet has been re-enabled, has run and the site should now be serving from origin as normal.")

--- a/mapit.py
+++ b/mapit.py
@@ -30,7 +30,7 @@ def update_database():
 
     # Run puppet, which will download the database dump, recreate the Mapit
     # database using the dump and start the services which were stopped earlier
-    execute(puppet.agent, '--test')
+    execute(puppet.agent)
 
 
 @task

--- a/puppet.py
+++ b/puppet.py
@@ -3,7 +3,7 @@ from time import sleep
 
 
 def puppet(*args):
-    sudo('govuk_puppet %s' % ' '.join(args))
+    sudo('govuk_puppet --test %s' % ' '.join(args))
 
 
 @task(default=True)


### PR DESCRIPTION
I think the vast majority of the time people running Puppet want to see what Puppet is doing.

If there are cases where we want Puppet to be quiet we can add a boolean option to do that.