### PR TITLE
Add alias to numbered task

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -263,7 +263,7 @@ def all():
     env.hosts.extend(env.roledefs['all']())
 
 
-@task
+@task(alias='num')
 @runs_once
 @serial
 def numbered(number):


### PR DESCRIPTION
I type this a lot so it would be nice to make it shorter:

```
fab staging class:etcd num:2 vm.uptime
```