### PR TITLE
Revert "Add a task to run a Rails app's console"

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 from fabric.api import sudo, task
-from util import bundle_exec
 
 
 @task
@@ -36,12 +35,6 @@ def start(app):
 def status(app):
     """Check status of a particular app"""
     _service(app, 'status')
-
-
-@task
-def rails_console(app):
-    """Attach to a Rails application's console"""
-    bundle_exec(app, 'rails console')
 
 
 def _service(app, command):


### PR DESCRIPTION
This reverts commit b48686004af33d06b33725014267e06d85458373.

While I agree with the intent behind this task, in practice I found that
using the Rails console via the Paramiko SSH library that Fabric uses
unbearably slow due to the high latency when typing commands. Therefore
I don't think this command is useful in practice.