### PR TITLE
Fix tests

### DIFF
--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 flake8==2.5.1
+pep8==1.6.2


### PR DESCRIPTION
When installing this freshly from master I get test failures.

- One is related to whitespace around arithmetic operators.
- The other is because of the way F403 is being parsed in the Makefile. I've made this less prone to breaking by including the comment separately.

```
F403:1:1: E902 IOError: [Errno 2] No such file or directory: 'F403'
```