### PR TITLE
Improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: "python"
 sudo: false # containerised builds
 install:
   - "pip install -q -r requirements_for_tests.txt"
+  - "pip freeze"
 script: "make test"


### PR DESCRIPTION
Run `pip freeze` as part of the CI build so that we can see what library
versions were used.

This should make it easier to debug any discrepancies between CI builds
and local builds in development.