### PR TITLE
Fix F403 lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
-	@flake8 . --exclude fabfile.py --ignore=E241,E501,F403 # FIXME: Fix these errors and stop ignoring them
+	@flake8 . --exclude fabfile.py --ignore=E241,E501
 	@flake8 fabfile.py --ignore=E241,E501,F401

--- a/apt.py
+++ b/apt.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import prompt, run, sudo, task
 
 
 @task

--- a/cache.py
+++ b/cache.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import roles, run, sudo, task
 
 
 @task

--- a/campaigns.py
+++ b/campaigns.py
@@ -1,6 +1,6 @@
 import StringIO
 
-from fabric.api import *
+from fabric.api import env, put, roles, runs_once, sudo, task
 from fabric.operations import prompt
 from fabric.tasks import execute
 

--- a/cdn.py
+++ b/cdn.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import env, execute, roles, run, runs_once, task
 from fabric.utils import abort
 
 import cache

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -1,5 +1,5 @@
 from distutils.version import StrictVersion
-from fabric.api import *
+from fabric.api import abort, env, execute, hide, run, runs_once, serial, settings, task
 from time import sleep
 import json
 import re

--- a/incident.py
+++ b/incident.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import roles, task
 from fabric.tasks import execute
 import nginx
 import puppet

--- a/logstream.py
+++ b/logstream.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import sudo, task
 
 
 @task

--- a/mainstream_slugs.py
+++ b/mainstream_slugs.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import task
 import util
 
 

--- a/mysql.py
+++ b/mysql.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import abort, env, hide, run, settings, task
 from fabric.operations import prompt
 
 

--- a/nagios.py
+++ b/nagios.py
@@ -1,7 +1,7 @@
 from urllib import quote_plus
 import json
 
-from fabric.api import *
+from fabric.api import abort, env, hide, hosts, prompt, run, runs_once, sudo, task
 
 
 NAGIOS_CMD_FILE = '/var/lib/icinga/rw/nagios.cmd'

--- a/nginx.py
+++ b/nginx.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import abort, run, sudo, task
 import fabric.contrib.files
 import puppet
 

--- a/ntp.py
+++ b/ntp.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import run, sudo, task
 
 
 @task

--- a/puppet.py
+++ b/puppet.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import env, hide, hosts, run, settings, sudo, task
 from time import sleep
 
 

--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import env, execute, hide, roles, sudo, task
 from time import sleep
 import re
 

--- a/rkhunter.py
+++ b/rkhunter.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import sudo, task
 
 
 @task(default=True)

--- a/search.py
+++ b/search.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import abort, cd, puts, sudo, task
 
 import util
 
@@ -58,13 +58,13 @@ def reindex(app=None):
 def reindex_app(app):
     puts("Rebuilding search index for application '%s'" % app)
 
-    machine_class, tasks = SEARCHABLE_APPS[app]
+    machine_class, rake_tasks = SEARCHABLE_APPS[app]
     util.use_random_host('class-%s' % machine_class)
 
-    for task in tasks:
+    for rake_task in rake_tasks:
         # FIXME: Remove this horrible hack of a hack for a hack
         if app == 'recommended-links':
             with cd('/data/vhost/recommended-links.*/current'):
-                sudo('govuk_setenv default bundle exec rake -v "%s" --trace' % task, user='deploy')
+                sudo('govuk_setenv default bundle exec rake -v "%s" --trace' % rake_task, user='deploy')
         else:
-            util.rake(app, task)
+            util.rake(app, rake_task)

--- a/statsd.py
+++ b/statsd.py
@@ -1,5 +1,5 @@
 import re
-from fabric.api import *
+from fabric.api import run, task
 
 
 @task

--- a/vm.py
+++ b/vm.py
@@ -1,4 +1,4 @@
-from fabric.api import *
+from fabric.api import env, execute, hide, hosts, parallel, run, sudo, task
 from fabric.utils import error
 import re
 


### PR DESCRIPTION
Fix F403 lint errors generated from flake8/pyflakes by using explicit
imports:

    ‘from module import *’ used; unable to detect undefined names