### PR TITLE
Remove unsupported/unused commands for apt

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -14,19 +14,6 @@ def security_updates():
 
 
 @task
-def upgrade():
-    """Upgrade packages with apt-get"""
-    sudo("apt-get update; apt-get upgrade -y")
-
-
-@task
-def dist_upgrade():
-    """Perform non-interactive dist-upgrade using apt-get"""
-    prompt('dist-upgrade is a dangerous operation, can remove packages and generally break all the things. Are you sure you want to proceed? (y/n)', validate=r'^[Yy]$')
-    sudo("apt-get -q update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" -yuq dist-upgrade")
-
-
-@task
 def unattended_upgrade():
     """Perform an unattended-upgrade"""
     sudo("unattended-upgrade -d")


### PR DESCRIPTION
We don't use these two apt commands and we shouldn't have to run them
manually, so remove them.

`upgrade()` is potentially bad because it can create disparity between
machines or environments. We automatically upgrade Ubuntu packages with
security updates using `unattended-upgrades` and we should use Puppet to
upgrade the packages we manage by setting `ensure` to `latest` where
appropriate.

`dist_upgrade()` is potentially bad for the same reasons, but also
because it may remove packages. There's no need for us to run it
manually.