### PR TITLE
Auto-correct server class name

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -283,6 +283,7 @@ def numbered(number):
 def klass(*class_names):
     """Select a machine class"""
     for class_name in class_names:
+        class_name = class_name.replace("-", "_")
         env.hosts.extend(env.roledefs['class-%s' % class_name]())
 
 


### PR DESCRIPTION
If a class has a dash in their name, this will replace it with
an underscore.

cc @alexmuller 