### PR TITLE
Wrappers around rummager snapshot/restore tasks

### DIFF
--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -94,6 +94,12 @@ def wait_for_status(*allowed):
 
 
 @task
+def check_recovery(index):
+    """Check status of an index recovery"""
+    return run("curl -XGET 'http://localhost:9200/{index}/_recovery'".format(index=index))
+
+
+@task
 @serial
 def safe_reboot():
     """Reboot only if the cluster is currently green"""

--- a/search.py
+++ b/search.py
@@ -68,3 +68,50 @@ def reindex_app(app):
                 sudo('govuk_setenv default bundle exec rake -v "%s" --trace' % rake_task, user='deploy')
         else:
             util.rake(app, rake_task)
+
+
+@task
+def find_latest_snapshot():
+    """Find the latest rummager snapshot"""
+    util.rake('rummager', 'rummager:snapshot:latest')
+
+
+@task
+def find_snapshot_for_date(date):
+    """Find the latest rummager snapshot before a date (YYYY-mm-dd HH:MM:SS)"""
+    util.rake('rummager', 'rummager:snapshot:latest', date)
+
+
+@task
+def list_snapshots():
+    """List rummager snapshots"""
+    util.rake('rummager', 'rummager:snapshot:list')
+
+
+@task
+def restore_snapshot(snapshot, groups_to_restore):
+    """Restore snapshots to new indices.
+
+    `groups_to_restore` is either 'all' or a comma separated list of aliases.
+    """
+    util.rake(
+        'rummager',
+        'rummager:snapshot:restore',
+        snapshot,
+        RUMMAGER_INDEX=groups_to_restore
+    )
+
+    puts(
+        "After the recovery is complete, switch to the new indexes with rummager.switch_group_to_index"
+    )
+
+
+@task
+def switch_group_to_index(group, index_name):
+    """Point a rummager index alias to a new index"""
+    util.rake(
+        'rummager',
+        'rummager:switch_to_named_index',
+        index_name,
+        RUMMAGER_INDEX=group
+    )


### PR DESCRIPTION
This relates to https://github.com/alphagov/rummager/pull/578 (not yet deployed), and https://github.com/alphagov/govuk-puppet/pull/4196.

We're implementing automatic snapshotting in rummager and have added some rake tasks to assist in restoring from snapshot. These are just wrappers around those tasks.

I figured this would be more useful than automating the process end to end, or using the jenkins rake job (e.g. https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=rummager&MACHINE=search-1.api&RAKE_TASK=rake%20rummager:snapshot:list) because there are multiple steps involved.

* Finding the snapshot you're interested in
* Restoring the snapshot to new indexes
* Waiting for those indexes to recover
* Pointing the aliases to the new indexes

We have some documentation on this at https://github.com/alphagov/rummager/blob/master/docs/snapshot-restore.md
We can move this to the ops manual if that's a better place for it.

cc @jackscotti 