### PR TITLE
Remove the 'unarchive content' task for Whitehall

### DIFF
--- a/whitehall.py
+++ b/whitehall.py
@@ -27,15 +27,6 @@ def dedupe_stats_announcement(duplicate_slug, authoritative_slug, noop=False):
 @task
 @runs_once
 @roles('class-whitehall_backend')
-def unarchive_content(*edition_ids):
-    """Unarchive Whitehall content"""
-    for edition_id in edition_ids:
-        util.rake('whitehall', 'unwithdraw_edition', edition_id)
-
-
-@task
-@runs_once
-@roles('class-whitehall_backend')
 def overdue_scheduled_publications():
     """List overdue scheduled publications"""
     util.rake('whitehall', 'publishing:overdue:list')


### PR DESCRIPTION
This rake task no longer exists since https://github.com/alphagov/whitehall/pull/2497
because the functionality is now self-servce for Whitehall editors.

**Note: this shouldn't be merged until https://github.com/alphagov/whitehall/pull/2497 is deployed**