### PR TITLE
Remove unused imports

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -1,4 +1,4 @@
-from fabric.api import prompt, run, sudo, task
+from fabric.api import run, sudo, task
 
 
 @task


### PR DESCRIPTION
424e93f0 removed some unused tasks, but did not remove the `prompt`
import because the work was done before acbbc88, which changed the
imports to be explicit.

Remove the unused import to fix the broken build on master.