### PR TITLE
Only show "more information" link when one is provided

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -39,13 +39,18 @@ def template(app):
     <div class="campaign-inner">
       <h1>{{ heading|e }}</h1>
       <p>{{ extra_info|e }}</p>
-      <a href="{{ more_info_url|e }}">More information</a>
+
+      {% if more_info_url %}
+        <a href="{{ more_info_url|e }}">More information</a>
+      {% endif %}
     </div>
   </div>""")
     elif app == 'static':
         template = Template("""<p>{{ heading|e }}<br />
     {{ extra_info|e }}</p>
-  <a href="{{ more_info_url|e }}" class="right">More information</a>""")
+      {% if more_info_url %}
+        <a href="{{ more_info_url|e }}" class="right">More information</a>
+      {% endif %}""")
 
     env['template_contents'] = template.render(env.context)
 


### PR DESCRIPTION
When there is a need of adding an emergency banner there is a chance that the link for "more information" is not filled.

This commit aims to remove the link when one is not provided when running the script.

**when a link is provided**

<img width="1069" alt="screen shot 2016-03-23 at 14 45 40" src="https://cloud.githubusercontent.com/assets/136777/13989179/15f8b5ca-f107-11e5-8b31-4bf62a67489d.png">


**when a link is not provided and banner is black**

<img width="1069" alt="screen shot 2016-03-23 at 14 45 23" src="https://cloud.githubusercontent.com/assets/136777/13989178/15f2b62a-f107-11e5-9e5a-77365eac3b17.png">

**when link is not provided and banner is green**

<img width="1069" alt="screen shot 2016-03-23 at 14 42 55" src="https://cloud.githubusercontent.com/assets/136777/13989177/15e13238-f107-11e5-989f-3d853ca462bd.png">

