### PR TITLE
Update emergency banner link class name.

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -49,7 +49,7 @@ def template(app):
         template = Template("""<p>{{ heading|e }}<br />
     {{ extra_info|e }}</p>
       {% if more_info_url %}
-        <a href="{{ more_info_url|e }}" class="right">More information</a>
+        <a href="{{ more_info_url|e }}" class="more-information">More information</a>
       {% endif %}""")
 
     env['template_contents'] = template.render(env.context)


### PR DESCRIPTION
`alphagov/frontend` has an updated class name for this element: https://github.com/alphagov/static/pull/767

This ensures the emergency banner references the new styles.

Relevant Trello ticket: https://trello.com/c/cm6VO0q4/341-emergency-publishing-frontend-bugs-medium