### PR TITLE
Extend mongo healthcheck timeout for restarts to 10s

### DIFF
--- a/mongo.py
+++ b/mongo.py
@@ -202,7 +202,7 @@ def safe_reboot():
     if i_am_primary(primary):
         execute(step_down_primary)
 
-    for i in range(5):
+    for i in range(10):
         if cluster_is_ok() and not i_am_primary():
             break
         sleep(1)


### PR DESCRIPTION
5s was shown to be too short for comfort in the last 2ndline rotation.