### PR TITLE
Update emergency publishing prompt text

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -26,9 +26,9 @@ def validate_classes(campaign_class):
 @runs_once
 def set_context():
     env['context'] = {
-        'heading': prompt("Heading for campaign:", 'heading'),
-        'extra_info': prompt("Extra information for campaign:", 'extra_info'),
-        'more_info_url': prompt("URL for more information:", 'more_info_url'),
+        'heading': prompt("Heading:", 'heading'),
+        'extra_info': prompt("Short description:", 'extra_info'),
+        'more_info_url': prompt("More info link:", 'more_info_url'),
         'campaign_class': prompt("Campaign class (one of {}):".format(", ".join(CAMPAIGN_CLASSES)), 'campaign_class', validate=validate_classes)
     }
 


### PR DESCRIPTION
This updates the text to match that in the 'Emergencies and GOV.UK' document. This makes the prompt more consistent and avoids doubt when running the script.

cc: @Shotclog, @sihugh  