### PR TITLE
Fix check database upgrade scripts

### DIFF
--- a/mapit.py
+++ b/mapit.py
@@ -51,9 +51,9 @@ def _restart_mapit_services():
 def check_database_upgrade():
     """Replay yesterday's Mapit requests to ensure that a database upgrade works"""
 
-    sudo("awk '$9==200 {print \"http://localhost\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-200s")
-    sudo("awk '$9==404 {print \"http://localhost\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-404s")
-    sudo("awk '$9==302 {print \"http://localhost\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-302s")
+    sudo("awk '$9==200 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-200s")
+    sudo("awk '$9==404 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-404s")
+    sudo("awk '$9==302 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-302s")
 
     print "Replaying Mapit 200s. Ensure that they are all still 200s."
     print "NOTE: Some 404s may result if internal ids have changed because /area/<code> will redirect to /area/<internal-id> - this should be a low number and for /area/ urls only"
@@ -61,6 +61,6 @@ def check_database_upgrade():
     print "Replaying Mapit 404s. Ensure that they are all either 200s or 404s."
     run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-404s | sort | uniq -c')
     print "Replaying Mapit 302s. Ensure that they are all still 302s. (these should be the /area/<code> redirects mentioned above)"
-    run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-404s | sort | uniq -c')
+    run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-302s | sort | uniq -c')
 
     sudo('rm ~/mapit-200s ~/mapit-404s ~/mapit-302s')


### PR DESCRIPTION
- Without specifying the port number, curl would not return a result, so we add it
- When replaying the 302s we were using the wrong file, so we update it