### PR TITLE
Fix rkhunter path

### DIFF
--- a/rkhunter.py
+++ b/rkhunter.py
@@ -4,7 +4,7 @@ from fabric.api import sudo, task
 @task(default=True)
 def check(*args):
     """Run rkhunter on the machine"""
-    sudo('/etc/cron.daily/rkhunter-passive-check')
+    sudo('/usr/local/bin/rkhunter-passive-check')
 
 
 @task


### PR DESCRIPTION
`rkhunter-passive-check` is now under `cron.d` instead of `cron.daily`.  This fixes the fabric script to point to the new location.

Here it is in [Puppet](https://github.com/alphagov/govuk-puppet/blob/master/modules/rkhunter/manifests/monitoring.pp#L66)

/cc @deanwilson 