### PR TITLE
Speed up MapIt tests

### DIFF
--- a/mapit.py
+++ b/mapit.py
@@ -51,9 +51,9 @@ def _restart_mapit_services():
 def check_database_upgrade():
     """Replay yesterday's Mapit requests to ensure that a database upgrade works"""
 
-    sudo("awk '$9==200 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-200s")
-    sudo("awk '$9==404 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-404s")
-    sudo("awk '$9==302 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 > mapit-302s")
+    sudo("awk '$9==200 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 | sort | uniq > mapit-200s")
+    sudo("awk '$9==404 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 | sort | uniq > mapit-404s")
+    sudo("awk '$9==302 {print \"http://localhost:3108\" $7}' /var/log/nginx/mapit.publishing.service.gov.uk-access.log.1 | sort | uniq > mapit-302s")
 
     print "Replaying Mapit 200s. Ensure that they are all still 200s."
     print "NOTE: Some 404s may result if internal ids have changed because /area/<code> will redirect to /area/<internal-id> - this should be a low number and for /area/ urls only"

--- a/mapit.py
+++ b/mapit.py
@@ -57,10 +57,10 @@ def check_database_upgrade():
 
     print "Replaying Mapit 200s. Ensure that they are all still 200s."
     print "NOTE: Some 404s may result if internal ids have changed because /area/<code> will redirect to /area/<internal-id> - this should be a low number and for /area/ urls only"
-    run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-200s | sort | uniq -c')
+    run('while read line; do curl -sI $line | grep HTTP/1 ; done < mapit-200s | sort | uniq -c')
     print "Replaying Mapit 404s. Ensure that they are all either 200s or 404s."
-    run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-404s | sort | uniq -c')
+    run('while read line; do curl -sI $line | grep HTTP/1 ; done < mapit-404s | sort | uniq -c')
     print "Replaying Mapit 302s. Ensure that they are all still 302s. (these should be the /area/<code> redirects mentioned above)"
-    run('while read line; do curl -sI $line | grep HTTP/1.1 ; done < mapit-302s | sort | uniq -c')
+    run('while read line; do curl -sI $line | grep HTTP/1 ; done < mapit-302s | sort | uniq -c')
 
     sudo('rm ~/mapit-200s ~/mapit-404s ~/mapit-302s')


### PR DESCRIPTION
When we deploy a new version of MapIt or a new database, we replay the previous
day's traffic against it to ensure that we can serve all the requests as least
as well as before.

It seems to add little value to request the same thing multiple times, and just
takes longer.  This will get the unique URLs instead of all of them.

To give some context about the scale of the problem, the last set of logs we
used for this process had 35,000 HTTP 200 responses in the day.  This would
have reduced to 18,000 unique requests, which still takes a little while to
replay, but half as long as before.

