### PR TITLE
Add a task to update the rkhunter files

### DIFF
--- a/rkhunter.py
+++ b/rkhunter.py
@@ -11,3 +11,9 @@ def check(*args):
 def propupdate(*args):
     """Update rkhunter file property database on the machine"""
     sudo('/usr/bin/rkhunter --propupdate')
+
+
+@task
+def update(*args):
+    """Update rkhunter, check for updates to database files"""
+    sudo('/usr/bin/rkhunter --update')


### PR DESCRIPTION
rkhunter-passive-check does not update the files in /var/lib/rkhunter/db if
there are no updates. However icinga will start alerting with `FILE_AGE WARNING`
if these files are not updated within 8 days.

The new task runs the same rkhunter task with the update database files flag
set.