### PR TITLE
Use curl --fail to determine purge failures

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -6,7 +6,7 @@ from fabric.api import roles, run, sudo, task
 def purge(*args):
     "Purge items from varnish, eg \"/one,/two,/three\""
     for path in args:
-        run("curl -s -I -X PURGE http://localhost:7999%s | grep '200 Purged'" % path.strip())
+        run("curl -s -I --fail -X PURGE http://localhost:7999%s" % path.strip())
 
 
 @task


### PR DESCRIPTION
This allows grep to not return an error code when the reason is different to "Purged".

This relates to: https://github.com/alphagov/govuk-puppet/pull/4872 where we allow varnish to return a 200 with a different reason for whitehall uploads.