### PR TITLE
Fix hostnames that end with the environment

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -231,6 +231,20 @@ def _set_gateway(jumpbox_domain):
     env.roledefs.fetch()
 
 
+def _replace_environment_hostnames(environment):
+    """
+    Users regularly specify environment as the suffix of a hostname when
+    sshing into a machine, thus a very common mistake is that fab processes
+    specify the host name with the environment. This replaces the environment
+    part of the host name and warns the user
+    """
+    suffix = "." + environment
+    for key, host in enumerate(env.hosts):
+        if host.endswith(suffix):
+            warn("host %s contains the environment which will automatically be removed" % host)
+            env.hosts[key] = host[:-len(suffix)]
+
+
 @task
 def help(name):
     """Show extended help for a task (e.g. 'fab help:search.reindex')"""
@@ -247,6 +261,7 @@ def production():
     """Select production environment"""
     env['environment'] = 'production'
     _set_gateway('publishing.service.gov.uk')
+    _replace_environment_hostnames('production')
 
 
 @task
@@ -254,6 +269,7 @@ def staging():
     """Select staging environment"""
     env['environment'] = 'staging'
     _set_gateway('staging.publishing.service.gov.uk')
+    _replace_environment_hostnames('staging')
 
 
 @task
@@ -261,6 +277,7 @@ def integration():
     """Select integration environment"""
     env['environment'] = 'integration'
     _set_gateway('integration.publishing.service.gov.uk')
+    _replace_environment_hostnames('integration')
 
 
 @task


### PR DESCRIPTION
A common developer mistake is to try fun fabric scripts by specifying the environment as part of the host name as this is how they ssh into the servers.

- `ssh backend-1.backend.integration` is how someone would ssh into a server
- whereas `fab integration -H backend-1.backend.integration` would result in a sudo prompt that you can't get past

This change outputs a warning when someone runs this command and removes the environment suffix.

Hopefully this will make lives easier. Although it would cause a problem if we had any hostnames that had the environment as part of the name e.g. `backend-1.integration.integration` but I don't believe that is the case