### PR TITLE
Fix Frontend campaign banner location

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -77,7 +77,7 @@ def clear_static_generated_templates():
 def deploy_banner(application):
     execute(template, application)
     if application == 'frontend':
-        remote_filename = '/var/apps/frontend/app/views/root/_campaign_notification.html.erb'
+        remote_filename = '/var/apps/frontend/app/views/homepage/_campaign_notification.html.erb'
     elif application == 'static':
         remote_filename = "/var/apps/static/app/views/notifications/banner_{}.erb".format(env.campaign_class)
     content = env['template_contents']
@@ -90,7 +90,7 @@ def deploy_banner(application):
 
 def remove_banner(application):
     if application == 'frontend':
-        remote_filenames = ['/var/apps/frontend/app/views/root/_campaign_notification.html.erb']
+        remote_filenames = ['/var/apps/frontend/app/views/homepage/_campaign_notification.html.erb']
     elif application == 'static':
         remote_filenames = ["/var/apps/static/app/views/notifications/banner_%s.erb" % i for i in CAMPAIGN_CLASSES]
     content = ''


### PR DESCRIPTION
GOV.UK homepage was not showing banners deployed through emergency
release procedures. This was caused by a change in the location of
the `_campaign_notification.html.erb` partial in Frontend.
The partial was moved from `/root` to `/homepage` (see https://github.com/alphagov/frontend/commit/8cb400defbe6228cc8ca3e7d69afe42a10ee3ced). This commit reflects the change of location in the fabric script.