### PR TITLE
Locksmith endpoint

### DIFF
--- a/locksmith.py
+++ b/locksmith.py
@@ -1,7 +1,6 @@
 from fabric.api import run, task
 from fabric.utils import error
 import fabric.contrib.files
-import util
 
 etcd_cluster = 'http://etcd-1.management:4001'
 locksmithctl = '/usr/bin/locksmithctl'
@@ -15,7 +14,6 @@ def check_locksmithctl():
 @task
 def status():
     """Get the status of locksmith"""
-    util.use_random_host('class-etcd')
     check_locksmithctl()
     run("{0} -endpoint='{1}' status".format(locksmithctl, etcd_cluster))
 
@@ -23,6 +21,5 @@ def status():
 @task
 def unlock(machine_name):
     """Unlock a machine with locksmith"""
-    util.use_random_host('class-etcd')
     check_locksmithctl()
     run("{0} -endpoint='{1}' unlock '{2}'".format(locksmithctl, etcd_cluster, machine_name))

--- a/locksmith.py
+++ b/locksmith.py
@@ -2,7 +2,7 @@ from fabric.api import run, task
 from fabric.utils import error
 import fabric.contrib.files
 
-etcd_cluster = 'http://etcd-1.management:4001'
+etcd_cluster = 'http://etcd.cluster:2379'
 locksmithctl = '/usr/bin/locksmithctl'
 
 


### PR DESCRIPTION
etcd was recently upgraded to version 3.x.  The current version conflates all endpoints in to the standard 2379 port, abolishing ports=4001 and 7001.
etcd run in a container that exposes it's ports.

Amended etcd endpoint.

See: https://trello.com/c/PWaGEYZE

Removed substituting hosts `util.use_random_host` function 

see: https://github.com/alphagov/fabric-scripts/commit/ab04af3004a3dd1a97f00a5e46463d5ad592f40a