### PR TITLE
Task to modify bundler task

### DIFF
--- a/bundler.py
+++ b/bundler.py
@@ -1,0 +1,42 @@
+from os.path import join
+from fabric.api import sudo, task
+from fabric.utils import error
+import fabric.contrib.files
+
+import puppet
+
+config_file_locations = [
+    '/home/deploy',
+    '/var/lib/jenkins'
+]
+
+config_file_suffix = '.bundle/config'
+
+
+def get_bundler_config():
+    for prefix in config_file_locations:
+        location = join(prefix, config_file_suffix)
+        if fabric.contrib.files.exists(location, use_sudo=True):
+            return location
+
+    error('Could not find bundler config file.')
+
+
+@task
+def failover_to_rubygems():
+    """Change bundler to use rubygems.org for gems rather than gemstash"""
+    bundler_config = get_bundler_config()
+    puppet.disable('Fabric failover_to_rubygems invoked')
+    # Overwrite the bundler config with an empty file to force failover to default
+    # Use an empty file rather than rm to avoid running rm as sudo.
+    sudo('echo "" > {0}'.format(bundler_config))
+    print('Disabled puppet and overwritten the bundler config file.')
+    print('Run "bundler.revert_mirror" to start using gemstash again.')
+
+
+@task
+def revert_mirror():
+    puppet.enable()
+    puppet.agent()
+    get_bundler_config()
+    print('Puppet has been re-enabled. The bundler config file should be in it\'s usual state.')

--- a/fabfile.py
+++ b/fabfile.py
@@ -20,6 +20,7 @@ import puppet
 # Our command submodules
 import app
 import apt
+import bundler
 import cache
 import campaigns
 import cdn

--- a/fabfile.py
+++ b/fabfile.py
@@ -9,6 +9,7 @@ import textwrap
 import time
 
 from fabric import state
+from fabric.main import show_commands
 from fabric.api import (abort, env, get, hide, hosts, local, puts, run,
                         runs_once, serial, settings, sudo, task, warn)
 from fabric.task_utils import crawl
@@ -244,8 +245,11 @@ def _replace_environment_hostnames(environment):
 
 
 @task
-def help(name):
+def help(name=""):
     """Show extended help for a task (e.g. 'fab help:search.reindex')"""
+    if not name:
+        puts("\nFor more information on a task run `fab help:<task>`.\n")
+        show_commands(None, 'short')
     task = crawl(name, state.commands)
 
     if task is None:


### PR DESCRIPTION
This adds a simple bundler task to clear any config settings being applied to bundler (e.g. in case the gemstash server has become unreachable).

It also improves the output of `fab help`.