### PR TITLE
Fix registration of tasks.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -9,7 +9,6 @@ import textwrap
 import time
 
 from fabric import state
-from fabric.main import show_commands
 from fabric.api import (abort, env, get, hide, hosts, local, puts, run,
                         runs_once, serial, settings, sudo, task, warn)
 from fabric.task_utils import crawl
@@ -249,6 +248,7 @@ def _replace_environment_hostnames(environment):
 @task
 def help(name=""):
     """Show extended help for a task (e.g. 'fab help:search.reindex')"""
+    from fabric.main import show_commands
     if not name:
         puts("\nFor more information on a task run `fab help:<task>`.\n")
         show_commands(None, 'short')


### PR DESCRIPTION
Importing show_commands was causing several tasks to be registered
under the 'elasticsearch' command, because of the ordering of imports.
Fix this by importing it directly within the help function where it is
used.