### PR TITLE
Upgrade paramiko

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Fabric==1.8.3
 GitPython==1.0.1
-paramiko==1.10.1
+paramiko==2.1.2
 pycrypto==2.6
 wsgiref==0.1.2
 jinja2==2.7.1


### PR DESCRIPTION
New machine will fail to log users in using their SSH keys with the older
version.

This is currently effecting `jumpbox-2.management.integration`