### PR TITLE
Remove emergency publishing deploy and removal scripts

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -1,64 +1,15 @@
-import StringIO
-
-from fabric.api import env, put, roles, runs_once, settings, sudo, task
-from fabric.operations import prompt
-from fabric.tasks import execute
-
-from jinja2 import Template
-
-import app
+from fabric.api import env, roles, settings, sudo, task
 
 
 env['eagerly_disconnect'] = True
 
 
-APPLICATIONS = ['static', 'frontend']
-CAMPAIGN_CLASSES = ['red', 'black', 'green']
 TEMPLATES = [
     'wrapper.html.erb',
     'homepage.html.erb',
     'header_footer_only.html.erb',
     'core_layout.html.erb',
 ]
-
-
-def validate_classes(campaign_class):
-    """Checks that the campaign class is valid"""
-    if campaign_class in CAMPAIGN_CLASSES:
-        return campaign_class
-    raise Exception("Invalid class {}, valid values are {}".format(campaign_class, CAMPAIGN_CLASSES))
-
-
-@runs_once
-def set_context():
-    env['context'] = {
-        'heading': prompt("Heading:", 'heading'),
-        'extra_info': prompt("Short description:", 'extra_info'),
-        'more_info_url': prompt("More info link:", 'more_info_url'),
-        'campaign_class': prompt("Campaign class (one of {}):".format(", ".join(CAMPAIGN_CLASSES)), 'campaign_class', validate=validate_classes)
-    }
-
-
-def template(app):
-    if app == 'frontend':
-        template = Template("""<div id="campaign" class="{{ campaign_class }}">
-    <div class="campaign-inner">
-      <h1>{{ heading|e }}</h1>
-      <p>{{ extra_info|e }}</p>
-
-      {% if more_info_url %}
-        <a href="{{ more_info_url|e }}">More information</a>
-      {% endif %}
-    </div>
-  </div>""")
-    elif app == 'static':
-        template = Template("""<p>{{ heading|e }}<br />
-    {{ extra_info|e }}</p>
-      {% if more_info_url %}
-        <a href="{{ more_info_url|e }}" class="more-information">More information</a>
-      {% endif %}""")
-
-    env['template_contents'] = template.render(env.context)
 
 
 def clear_static_generated_templates():
@@ -87,51 +38,6 @@ def clear_frontend_cache():
 
 def clear_government_frontend_cache():
     sudo("rm -rf /var/apps/government-frontend/tmp/cache/*")
-
-
-def deploy_banner(application):
-    execute(template, application)
-    if application == 'frontend':
-        remote_filename = '/var/apps/frontend/app/views/homepage/_campaign_notification.html.erb'
-    elif application == 'static':
-        remote_filename = "/var/apps/static/app/views/notifications/banner_{}.erb".format(env.campaign_class)
-    content = env['template_contents']
-    put(StringIO.StringIO(content), remote_filename, use_sudo=True, mirror_local_mode=True)
-    sudo('chown deploy:deploy %s' % remote_filename)
-    execute(app.restart, application)
-    if application == 'static':
-        clear_static_generated_templates()
-
-
-def remove_banner(application):
-    if application == 'frontend':
-        remote_filenames = ['/var/apps/frontend/app/views/homepage/_campaign_notification.html.erb']
-    elif application == 'static':
-        remote_filenames = ["/var/apps/static/app/views/notifications/banner_%s.erb" % i for i in CAMPAIGN_CLASSES]
-    content = ''
-    for remote_filename in remote_filenames:
-        put(StringIO.StringIO(content), remote_filename, use_sudo=True, mirror_local_mode=True)
-        sudo('chown deploy:deploy %s' % remote_filename)
-    execute(app.restart, application)
-    if application == 'static':
-        clear_static_generated_templates()
-
-
-@task
-@roles('class-frontend')
-def deploy_emergency_banner():
-    """Deploy an emergency banner to GOV.UK"""
-    execute(set_context)
-    for application in APPLICATIONS:
-        deploy_banner(application)
-
-
-@task
-@roles('class-frontend')
-def remove_emergency_banner():
-    """Remove all banners from GOV.UK"""
-    for application in APPLICATIONS:
-        remove_banner(application)
 
 
 @task


### PR DESCRIPTION
Emergency banner publishing is now done with a Jenkins task.
Remove the deprecated fabric scripts.

Trello card: https://trello.com/c/GZh4Rvpz/923-remove-old-emergency-banner-code-partials-and-tests

[Related PR 1018 in static](https://github.com/alphagov/static/pull/1018)
[Related PR 1217 in frontend](https://github.com/alphagov/frontend/pull/1217)
[Related PR 203 in govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs/pull/203)