### PR TITLE
Add task to clear government-frontend rails cache

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -85,6 +85,10 @@ def clear_frontend_cache():
     sudo("rm -rf /var/apps/frontend/tmp/cache/*")
 
 
+def clear_government_frontend_cache():
+    sudo("rm -rf /var/apps/government-frontend/tmp/cache/*")
+
+
 def deploy_banner(application):
     execute(template, application)
     if application == 'frontend':
@@ -133,8 +137,6 @@ def remove_emergency_banner():
 @task
 @roles('class-frontend')
 def clear_cached_templates():
-    for application in APPLICATIONS:
-        if application == 'frontend':
-            clear_frontend_cache()
-        if application == 'static':
-            clear_static_generated_templates()
+    clear_frontend_cache()
+    clear_static_generated_templates()
+    clear_government_frontend_cache()


### PR DESCRIPTION
When deploying and removing emergency banners, we also want to clear the
cache for government-frontend. Add a method to do this and call it from
the clear_cached_templates function.

Also a small refactor since we don't realy need to iterate over the
APPLICATIONS list in that function.

Trello: https://trello.com/c/pj4sOsb2/926-bug-new-emergency-banner-does-not-display-on-pages-rendered-by-government-frontend-or-whitehall-frontend