### PR TITLE
Update script description

### DIFF
--- a/vm.py
+++ b/vm.py
@@ -62,7 +62,7 @@ def bodge_unicorn(name):
     """
     Manually kill off (and restart) unicorn processes by name
 
-    e.g. vm.bodge_unicorn:contentapi
+    e.g. vm.bodge_unicorn:content-tagger
 
     Yes. This is a bodge. Sorry.
     """


### PR DESCRIPTION
Updates the usage since contentapi has been deprecated with
content-tagger

Paired with @Rosa-Fox 
Trello: https://trello.com/c/2MF97xce/154-retire-content-api