### PR TITLE
Clear finder frontend caches

### DIFF
--- a/campaigns.py
+++ b/campaigns.py
@@ -1,4 +1,4 @@
-from fabric.api import env, roles, settings, sudo, task
+from fabric.api import env, roles, settings, sudo, task, execute
 
 
 env['eagerly_disconnect'] = True
@@ -12,6 +12,7 @@ TEMPLATES = [
 ]
 
 
+@roles('class-frontend')
 def clear_static_generated_templates():
     """
     Our various frontend applications use the wrapper.html.erb,
@@ -32,17 +33,18 @@ def clear_static_generated_templates():
             sudo('rm /var/apps/static/public/templates/{}'.format(template))
 
 
+@roles('class-frontend')
 def clear_frontend_cache():
     sudo("rm -rf /var/apps/frontend/tmp/cache/*")
 
 
+@roles('class-frontend')
 def clear_government_frontend_cache():
     sudo("rm -rf /var/apps/government-frontend/tmp/cache/*")
 
 
 @task
-@roles('class-frontend')
 def clear_cached_templates():
-    clear_frontend_cache()
-    clear_static_generated_templates()
-    clear_government_frontend_cache()
+    execute(clear_frontend_cache)
+    execute(clear_static_generated_templates)
+    execute(clear_government_frontend_cache)

--- a/campaigns.py
+++ b/campaigns.py
@@ -43,8 +43,14 @@ def clear_government_frontend_cache():
     sudo("rm -rf /var/apps/government-frontend/tmp/cache/*")
 
 
+@roles('class-calculators_frontend')
+def clear_finder_frontend_cache():
+    sudo("rm -rf /var/apps/finder-frontend/tmp/cache/*")
+
+
 @task
 def clear_cached_templates():
     execute(clear_frontend_cache)
     execute(clear_static_generated_templates)
     execute(clear_government_frontend_cache)
+    execute(clear_finder_frontend_cache)


### PR DESCRIPTION
Finder Frontend is served by calculators-frontend boxes. Add a function
to clear the caches on Finder Frontend.

When releasing emergency publishing banners, one of the steps is to run
`campaigns.clear_cached_templates` fabric task. This commit ensures
Finder Frontend caches also get cleared predictably.

[Trello](https://trello.com/c/24hZL90j/67-emergency-publishing-drill-week-of-7th-13th)