### PR TITLE
Add email alert api rake tasks

### DIFF
--- a/emailalertapi.py
+++ b/emailalertapi.py
@@ -7,3 +7,10 @@ import util
 def deliver_test_email(address):
     """Delivers a test email to address"""
     util.rake('email-alert-api', 'deliver:to_test_email', address)
+
+
+@task
+@hosts('email-alert-api-1.backend')
+def truncate_tables():
+    """Truncates tables - ONLY USE ON INITIAL DEPLOY"""
+    util.rake('email-alert-api', 'deploy:truncate_tables')

--- a/emailalertapi.py
+++ b/emailalertapi.py
@@ -1,0 +1,9 @@
+from fabric.api import task, hosts
+import util
+
+
+@task
+@hosts('email-alert-api-1.backend')
+def deliver_test_email(address):
+    """Delivers a test email to address"""
+    util.rake('email-alert-api', 'deliver:to_test_email', address)

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,6 +24,7 @@ import cache
 import campaigns
 import cdn
 import elasticsearch
+import emailalertapi
 import incident
 import jenkins
 import locksmith


### PR DESCRIPTION
Adding two fab tasks which call Email Alert Api rake tasks:

* Deliver test email
* Truncate tables

These will both be used during our deploy when we switch over from GovDelivery to Notify as our email provider. These fabric tasks ease our deploy process since we will not have to rely on either sshing or Jenkins to run these tasks. This in turn keeps us at the command line in one context, running fab tasks as much as possible.

We should ultimately keep the deliver test email task because it will be useful in any debugging scenarios in the future. However we should remove the truncate table task to avoid accidentally deleting production data.

[Trello - Dry run todos](https://trello.com/c/HX9boFIl/652-dry-run-todos)
[Trello - Post deploy cleanups](https://trello.com/c/iKEAnrN2/468-post-deploy-development-cleanup)