### PR TITLE
Add task to return Email Alert Api table counts

### DIFF
--- a/emailalertapi.py
+++ b/emailalertapi.py
@@ -14,3 +14,10 @@ def deliver_test_email(address):
 def truncate_tables():
     """Truncates tables - ONLY USE ON INITIAL DEPLOY"""
     util.rake('email-alert-api', 'deploy:truncate_tables')
+
+
+@task
+@hosts('email-alert-api-1.backend')
+def table_counts():
+    """Returns a count of rows in each table in the email-alert-api database"""
+    util.rake('email-alert-api', 'deploy:count_tables')


### PR DESCRIPTION
Calls the rake task in Email Alert Api to return the row counts of each
table in the database.

[Trello](https://trello.com/c/HX9boFIl/652-dry-run-todos)