### PR TITLE
Remove Email Alert Api deployment convenience methods

### DIFF
--- a/emailalertapi.py
+++ b/emailalertapi.py
@@ -7,17 +7,3 @@ import util
 def deliver_test_email(address):
     """Delivers a test email to address"""
     util.rake('email-alert-api', 'deliver:to_test_email', address)
-
-
-@task
-@hosts('email-alert-api-1.backend')
-def truncate_tables():
-    """Truncates tables - ONLY USE ON INITIAL DEPLOY"""
-    util.rake('email-alert-api', 'deploy:truncate_tables')
-
-
-@task
-@hosts('email-alert-api-1.backend')
-def table_counts():
-    """Returns a count of rows in each table in the email-alert-api database"""
-    util.rake('email-alert-api', 'deploy:count_tables')


### PR DESCRIPTION
Two fab tasks that were used during the greate switchover to Notify.
They are no longer needed.
We really don't want to accidentally truncate tables anymore and the
table row counts were only there as a sanity check.