### PR TITLE
Remove old email-alert-api tasks

### DIFF
--- a/emailalertapi.py
+++ b/emailalertapi.py
@@ -7,17 +7,3 @@ import util
 def deliver_test_email(address):
     """Delivers a test email to address"""
     util.rake('email-alert-api', 'deliver:to_test_email', address)
-
-
-@task
-@hosts('email-alert-api-1.backend')
-def truncate_tables():
-    """Truncates tables - ONLY USE ON INITIAL DEPLOY"""
-    util.rake('email-alert-api', 'deploy:truncate_tables')
-
-
-@task
-@hosts('email-alert-api-1.backend')
-def table_counts():
-    """Returns a count of rows in each table in the email-alert-api database"""
-    util.rake('email-alert-api', 'deploy:count_tables')


### PR DESCRIPTION
These tasks no longer exist so we can't call them.

[Trello Card](https://trello.com/c/iKEAnrN2/680-post-deploy-development-cleanup)