### PR TITLE
Provide `apt.update` task

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -48,3 +48,9 @@ def autoremove():
 def autoremove_dry_run():
     """Run `apt-get autoremove` dry run"""
     sudo('apt-get autoremove --dry-run')
+
+
+@task
+def update():
+    """Run `apt-get update`"""
+    sudo('apt-get update')


### PR DESCRIPTION
This runs `apt-get update`.  Machines are configured to run this daily,
but we may need to force a run quicker than that.  For example to pick up
a new version of ruby we've made available and want to deploy quickly in
the case of security vulnerabilities.