### PR TITLE
Puppet clear old certs

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -286,6 +286,17 @@ def integration(stackname=None):
 
 
 @task
+def aws_staging(stackname=None):
+    if not stackname:
+        stackname = 'blue'
+
+    """Select GOV.UK AWS Staging  environment"""
+    env['environment'] = 'staging'
+    _set_gateway("{}.staging.govuk.digital".format(stackname))
+    _replace_environment_hostnames("{}.staging".format(stackname))
+
+
+@task
 def all():
     """Select all machines in current environment"""
     env.hosts.extend(env.roledefs['all']())


### PR DESCRIPTION
https://trello.com/c/nr8kuCOv/1170-aws-staging-puppet-is-broken

- We have a requirement to do the following when a puppet master dies.
 - Remove old certificates from the puppet clients.
 - Create a new Certificate Signing Request(CSR) from the client to the
master.
 - Sign the certificate via the master.
 - Perform a puppet run on the client.

- We have introduced two tasks to perform the requirements above.

- We have created a `cert_clean` task to clean old certificates and
execute an initial CSR.

- We have created another task called `agent_run` to perform a puppet
run on the clients. There is an existing agent task. However, this task
will accomodate some errors(python exceptions) that we have seen during
a clean-up.

- We have also intoduced an environment called `aws-staging` to accommodate
our AWS instances.

Solo: @suthagarht