### PR TITLE
Enforce use of classes for all tasks

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,8 +1,7 @@
-from fabric.api import roles, run, sudo, task
+from fabric.api import run, sudo, task
 
 
 @task
-@roles('cache', 'draft_cache')
 def purge(*args):
     "Purge items from varnish, eg \"/one,/two,/three\""
     for path in args:
@@ -10,7 +9,6 @@ def purge(*args):
 
 
 @task
-@roles('cache', 'draft_cache')
 def ban_all():
     """
     Invalidate all current cached objects in varnish.
@@ -25,7 +23,6 @@ def ban_all():
 
 
 @task
-@roles('cache', 'draft_cache')
 def restart():
     """
     Restart Varnish caches
@@ -34,7 +31,6 @@ def restart():
 
 
 @task(default=True)
-@roles('cache', 'draft_cache')
 def stats():
     "Show details about varnish performance"
     sudo('varnishstat -1')

--- a/cdn.py
+++ b/cdn.py
@@ -1,4 +1,4 @@
-from fabric.api import env, execute, roles, run, runs_once, task
+from fabric.api import env, execute, run, runs_once, task
 from fabric.utils import abort
 
 import cache
@@ -6,7 +6,6 @@ import cache
 
 @task
 @runs_once
-@roles('cache')
 def fastly_purge(*args):
     "Purge items from Fastly, eg \"/one,/two,/three\". Wildcards not supported."
     if env.environment == 'production':

--- a/incident.py
+++ b/incident.py
@@ -1,11 +1,10 @@
-from fabric.api import roles, task
+from fabric.api import task
 from fabric.tasks import execute
 import nginx
 import puppet
 
 
 @task
-@roles('cache')
 def fail_to_mirror():
     """Fails the site to the mirror by stopping nginx on the cache nodes"""
     puppet.disable("Fabric fail_to_mirror task invoked")
@@ -15,7 +14,6 @@ def fail_to_mirror():
 
 
 @task
-@roles('cache')
 def recover_origin():
     """Recovers GOV.UK to serve from origin after incident.fail_to_mirror has been invoked"""
     puppet.enable()

--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -1,10 +1,9 @@
-from fabric.api import env, execute, hide, roles, sudo, task
+from fabric.api import env, execute, hide, sudo, task
 from time import sleep
 import re
 
 
 @task
-@roles('rabbitmq')
 def status():
     """Output the RabbitMQ cluster status"""
     sudo('rabbitmqctl cluster_status', warn_only=True)
@@ -55,7 +54,6 @@ def cluster_is_ok():
 
 
 @task
-@roles('rabbitmq')
 def safe_reboot():
     """Reboot rabbitmq machines, waiting for cluster to be healthy first"""
     import vm

--- a/whitehall.py
+++ b/whitehall.py
@@ -1,4 +1,4 @@
-from fabric.api import task, execute, runs_once, roles
+from fabric.api import task, execute, runs_once
 import util
 
 
@@ -14,7 +14,6 @@ def dedupe_stats_announcement_from_file(filename):
 
 @task
 @runs_once
-@roles('whitehall_backend')
 def dedupe_stats_announcement(duplicate_slug, authoritative_slug, noop=False):
     """De-duplicate Whitehall statistics announcement"""
     option = ' -n' if noop else ''
@@ -26,7 +25,6 @@ def dedupe_stats_announcement(duplicate_slug, authoritative_slug, noop=False):
 
 @task
 @runs_once
-@roles('whitehall_backend')
 def overdue_scheduled_publications():
     """List overdue scheduled publications"""
     util.rake('whitehall', 'publishing:overdue:list')
@@ -34,7 +32,6 @@ def overdue_scheduled_publications():
 
 @task
 @runs_once
-@roles('whitehall_backend')
 def schedule_publications():
     """Publish overdue scheduled publications"""
     util.rake('whitehall', 'publishing:overdue:publish')
@@ -42,7 +39,6 @@ def schedule_publications():
 
 @task
 @runs_once
-@roles('whitehall_backend')
 def unpublish_statistics_announcement(*slugs):
     """Unpublish statistics announcements and register 410 GONE routes"""
     for slug in slugs:


### PR DESCRIPTION
https://trello.com/c/lDiAvOhV/145-speedup-fabric-scripts-so-theyre-quicker-than-doing-stuff-manually

Previously some fabric tasks would automatically set the group of
hosts on which they should run, such as 'cache' or 'whitehall_backend'.
The code to support this magic was causing all fabric tasks to take a
long time to run. As only a few tasks had this behaviour, it's more
consistent to enforce the group of hosts be specified when running all
fabric tasks, while also making it easy to remove the task bottleneck.