### PR TITLE
Remove old email-alert-api tasks

### DIFF
--- a/emailalertapi.py
+++ b/emailalertapi.py
@@ -1,9 +1,0 @@
-from fabric.api import task, hosts
-import util
-
-
-@task
-@hosts('email-alert-api-1.backend')
-def deliver_test_email(address):
-    """Delivers a test email to address"""
-    util.rake('email-alert-api', 'deliver:to_test_email', address)

--- a/fabfile.py
+++ b/fabfile.py
@@ -23,7 +23,6 @@ import bundler
 import cache
 import cdn
 import elasticsearch
-import emailalertapi
 import incident
 import jenkins
 import locksmith


### PR DESCRIPTION
These aren't documented and we have Rake tasks in Jenkins for this.