### PR TITLE
Add new environment: aws_production

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -145,6 +145,17 @@ def aws_staging(stackname=None):
 
 
 @task
+def aws_production(stackname=None):
+    if not stackname:
+        stackname = 'blue'
+
+    """Select GOV.UK AWS Production  environment"""
+    env['environment'] = 'production'
+    env['aws_migration'] = True
+    _set_gateway("{}.production.govuk.digital".format(stackname))
+
+
+@task
 def all():
     """Select all machines in current environment"""
     env.hosts.extend(fetch_hosts())


### PR DESCRIPTION
  As part of the migration of GOV.UK to AWS we need to execute
fabric scripts on the new production environment built on AWS.