### PR TITLE
Ignore .venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .ssh/*
 *.sqlite
+.venv


### PR DESCRIPTION
This commit adds the `.venv` directory to the `.gitignore` file. The developer docs instructions create the `.venv` directory at the top level, so it should be ignored.