### PR TITLE
Rewrite elasticsearch tasks for AWS managed elasticsearch

### DIFF
--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -25,12 +25,6 @@ def cluster_health():
 
 
 @task
-def cluster_nodes():
-    """Get cluster nodes"""
-    return run("curl -XGET 'http://localhost:9200/_cluster/nodes?pretty'")
-
-
-@task
 def check_recovery(index):
     """Check status of an index recovery"""
     return run("curl -XGET 'http://localhost:9200/{index}/_recovery'".format(index=index))

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -1,12 +1,23 @@
 from fabric.api import abort, run, task
 import re
 
+ELASTICSEARCH_HOST = 'http://localhost:9200'
+
+
+def query_elasticsearch(path, method='GET', host=ELASTICSEARCH_HOST, *args, **kwargs):
+    curl_command = "curl -X{method} '{host}/{path}'".format(
+        method=method,
+        host=host,
+        path=path
+    )
+    return run(curl_command, *args, **kwargs)
+
 
 @task
 def delete(index):
     """Delete an index"""
     if re.match('^[^/]+$', index):
-        run("curl -XDELETE 'http://localhost:9200/%s'" % index)
+        query_elasticsearch(index, method='DELETE')
     else:
         abort("Invalid index provided '%s'" % index)
 
@@ -14,17 +25,16 @@ def delete(index):
 @task
 def status(index):
     """Get the status of an index"""
-    run("curl -XGET 'http://localhost:9200/%s/_status'" % index)
+    query_elasticsearch(index + '/_status')
 
 
 @task
 def cluster_health():
     """Get cluster status"""
-    return run("curl -XGET 'http://localhost:9200/_cluster/health?pretty'",
-               warn_only=True)
+    return query_elasticsearch('/_cluster/health?pretty', warn_only=True)
 
 
 @task
 def check_recovery(index):
     """Check status of an index recovery"""
-    return run("curl -XGET 'http://localhost:9200/{index}/_recovery'".format(index=index))
+    return query_elasticsearch(index + '/_recovery')

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -1,7 +1,7 @@
 from fabric.api import abort, run, task
 import re
 
-ELASTICSEARCH_HOST = 'http://localhost:9200'
+ELASTICSEARCH_HOST = 'http://elasticsearch5:80'
 
 
 def query_elasticsearch(path, method='GET', host=ELASTICSEARCH_HOST, *args, **kwargs):

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -14,27 +14,27 @@ def query_elasticsearch(path, method='GET', host=ELASTICSEARCH_HOST, *args, **kw
 
 
 @task
-def delete(index):
+def delete(index, host=ELASTICSEARCH_HOST):
     """Delete an index"""
     if re.match('^[^/]+$', index):
-        query_elasticsearch(index, method='DELETE')
+        query_elasticsearch(index, method='DELETE', host=host)
     else:
         abort("Invalid index provided '%s'" % index)
 
 
 @task
-def status(index):
+def status(index, host=ELASTICSEARCH_HOST):
     """Get the status of an index"""
-    query_elasticsearch(index + '/_status')
+    query_elasticsearch(index + '/_status', host=host)
 
 
 @task
-def cluster_health():
+def cluster_health(host=ELASTICSEARCH_HOST):
     """Get cluster status"""
-    return query_elasticsearch('/_cluster/health?pretty', warn_only=True)
+    return query_elasticsearch('/_cluster/health?pretty', host=host, warn_only=True)
 
 
 @task
-def check_recovery(index):
+def check_recovery(index, host=ELASTICSEARCH_HOST):
     """Check status of an index recovery"""
-    return query_elasticsearch(index + '/_recovery')
+    return query_elasticsearch(index + '/_recovery', host=host)


### PR DESCRIPTION
Most of them have gone away because they're either things which have been deprecated since elastiscsearch 1.0 or things which we don't/can't do with AWS managed elasticsearch (get information about the cluster nodes / reboot them).

The remaining tasks take the host as an optional parameter.  The default is still the elasticsearch 2 cluster, but that can be changed later.

---

[Trello card](https://trello.com/c/u3KheCGE/65-update-fabric-scripts-that-interact-with-elasticsearch)