### PR TITLE
Add a script for restarting CKAN harvesters

### DIFF
--- a/ckan.py
+++ b/ckan.py
@@ -1,0 +1,45 @@
+from __future__ import print_function
+
+from fabric.api import settings, sudo, task
+
+
+class HarvesterServiceStopped(Exception):
+    pass
+
+
+def restart_harvester_process(type):
+    service_name = 'harvester_{type}_consumer-procfile-worker'.format(type=type)
+    service_name_child = service_name + '_child'
+
+    print('Checking status of:', service_name)
+
+    with settings(abort_exception=HarvesterServiceStopped):
+        try:
+            check_started_command = 'initctl list | grep {service} | grep start'
+            sudo(check_started_command.format(service=service_name_child))
+        except HarvesterServiceStopped:
+            print('Service has stopped, restarting...')
+            sudo('initctl stop {service}'.format(service=service_name))
+            sudo('initctl start {service}'.format(service=service_name))
+
+
+@task
+def restart_harvester_gather():
+    """Restart gather harvester process."""
+
+    restart_harvester_process('gather')
+
+
+@task
+def restart_harvester_fetch():
+    """Restart fetch harvester process."""
+
+    restart_harvester_process('fetch')
+
+
+@task
+def restart_harvester():
+    """Restart harvester process."""
+
+    restart_harvester_gather()
+    restart_harvester_fetch()

--- a/fabfile.py
+++ b/fabfile.py
@@ -21,6 +21,7 @@ import app
 import apt
 import bundler
 import cache
+import ckan
 import elasticsearch
 import incident
 import jenkins


### PR DESCRIPTION
They often crash and this Fabric script makes it really easy to restart them. It first checks that they are indeed not running meaning that you can even run the script without having to check first, i.e. every morning.

You can use it like this: `fab aws_production class:ckan ckan.restart_harvester`

[Trello Card](https://trello.com/c/07jTJBX5/823-make-ckan-harvesting-restart-when-it-fails)