### PR TITLE
Add tasks to disable and enable sending to logit

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -23,6 +23,7 @@ import bundler
 import cache
 import ckan
 import elasticsearch
+import filebeat
 import incident
 import jenkins
 import locksmith

--- a/filebeat.py
+++ b/filebeat.py
@@ -1,0 +1,21 @@
+from fabric.api import sudo, task, hide
+import puppet
+
+
+@task
+def disable_logit():
+    """Disable filebeat so we don't send data to Logit.io"""
+    with hide('everything'):
+        locked = sudo('test -f /var/lib/puppet/state/agent_disabled.lock && echo DISABLED || echo ENABLED')
+
+    if locked == "ENABLED":
+        puppet.disable("Disable sending to logit")
+
+    sudo("service filebeat stop")
+
+
+@task
+def enable_logit():
+    """Updates filebeat.yml and enables sending to logit"""
+    puppet.enable()
+    sudo("service filebeat start")


### PR DESCRIPTION
When load testing GOV.UK we can send large amounts of logs to Logit.io.
We don't always want to send this data because it can result in us going
over our quota for the month.

These tasks make it easy to disable sending the data before executing a
load test and then re-enabling it afterwards by stopping and starting
the filebeat service.

You can disable sending data to logit by doing something like:

```
fab integration class:calculators_frontend filebeat.disable_logit
```

[Trello](https://trello.com/c/l6s89IKZ/1280-run-a-load-test-for-brexit-checker-email-subscription-800-workers-for-10-mins)