### PR TITLE
Support staging_aws and production_aws

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -137,6 +137,11 @@ def aws_staging(stackname=None):
 
 
 @task
+def staging_aws(stackname=None):
+    return aws_staging(stackname)
+
+
+@task
 def aws_production(stackname=None):
     if not stackname:
         stackname = 'blue'
@@ -145,6 +150,11 @@ def aws_production(stackname=None):
     env['environment'] = 'production'
     env['aws_migration'] = True
     env.gateway = 'jumpbox.blue.production.govuk.digital'
+
+
+@task
+def production_aws(stackname=None):
+    return aws_production(stackname)
 
 
 @task


### PR DESCRIPTION
I seem to always forget where the `aws` goes (and always gets it wrong the first time 🙄). I think this is because `govukcli set-context` has the `aws` at the end which is opposite to the ordering of the current Fabric tasks.

This PR allows you to type in both ways.