### PR TITLE
Point elasticsearch fab tasks to ES6 host

### DIFF
--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -1,7 +1,7 @@
 from fabric.api import abort, run, task
 import re
 
-ELASTICSEARCH_HOST = 'http://elasticsearch5:80'
+ELASTICSEARCH_HOST = 'http://elasticsearch6:80'
 
 
 def query_elasticsearch(path, method='GET', host=ELASTICSEARCH_HOST, *args, **kwargs):


### PR DESCRIPTION
I'm *pretty confident* that nobody uses these, but it's an easy fix.