### PR TITLE
Check nginx config before gracefulrestart

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -27,6 +27,12 @@ def disable_maintenance():
     puppet.enable()
 
 
+@task
+def configtest():
+    """Tests the Nginx configuration"""
+    sudo('service nginx configtest')
+
+
 def gracefulstop(wait=True):
     """Gracefully shutdown Nginx by finishing any in-flight requests"""
     sudo('nginx -s quit')
@@ -37,8 +43,10 @@ def gracefulstop(wait=True):
 
 
 @task
-def gracefulrestart():
+def gracefulrestart(force=False):
     """Gracefully shutdown and start Nginx (not reload)"""
+    if not force:
+        configtest()
     gracefulstop()
     start()
 


### PR DESCRIPTION
The name `nginx.gracefulrestart` implies two things: nginx will be restarted, and it will be graceful. However, if the nginx config file is invalid, this task will still stop nginx, nicely draining all the connections, but then won't be able to start it back up again.

`configtest` simply runs `nginx -t` to test the configuration. This is now a step to run in the `gracefulrestart` task - hopefully preventing nginx from being shut down if it won't be able to start back up!