### PR TITLE
Remove `import statsd`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 test:
 	@flake8 . --exclude fabfile.py --ignore=E241,E501
 	@flake8 fabfile.py --ignore=E241,E501,F401
+	@fab -l

--- a/fabfile.py
+++ b/fabfile.py
@@ -35,7 +35,6 @@ import ntp
 import postgresql
 import rabbitmq
 import rbenv
-import statsd
 import vm
 
 HERE = os.path.dirname(__file__)


### PR DESCRIPTION
This file was removed in https://github.com/alphagov/fabric-scripts/pull/291 but for most people the scripts continued working because a compiled file `statsd.pyc` would have been left behind from the last time they ran the fabric scripts.

Only if people were starting fresh with these scripts would it have been a problem.