### PR TITLE
Add a fabric module for the upcoming publisher maintenance

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -36,6 +36,7 @@ import postgresql
 import rabbitmq
 import rbenv
 import vm
+import publisher_maintenance
 
 HERE = os.path.dirname(__file__)
 
@@ -233,5 +234,6 @@ def do(command):
 def sdo(command):
     """Execute arbitrary commands with sudo"""
     sudo(command)
+
 
 _check_repo_age()

--- a/publisher_maintenance.py
+++ b/publisher_maintenance.py
@@ -1,0 +1,49 @@
+from fabric.api import abort, sudo, task, cd
+import fabric.contrib.files
+import puppet
+
+maintenance_config = '/etc/nginx/includes/maintenance.conf'
+
+valid_apps = set([
+    "collections-publisher",
+    "contacts-admin",
+    "search-admin",
+    "service-manual-publisher",
+    "content-tagger",
+    "content-publisher",
+    "publisher",
+    "manuals-publisher",
+    "short-url-manager",
+    "specialist-publisher",
+    "hmrc-manuals-api",
+    "maslow",
+    "travel-advice-publisher",
+])
+
+
+@task
+def enable_maintenance(*app_list):
+    """Enables a maintenance page for publishers and serves a 503"""
+    """Only to be run on loadbalancers"""
+    if not fabric.contrib.files.exists(maintenance_config):
+        abort("Sorry this task can only currently be run on loadbalancers")
+    # puppet.disable("Maintenance mode enabled")
+    env_url_post = fabric.state.env.gateway.lstrip("jumpbox.")
+    app_list = list(app_list)
+    if not valid_apps.issuperset(app_list):
+        print("{} are not valid apps for this maintenance.".format(
+            list(set(app_list).difference(valid_apps))))
+        exit(1)
+    for app in app_list:
+        app_hostname = "{}.{}".format(app, env_url_post)
+        app_config_file = "/etc/nginx/sites-enabled/{}".format(app_hostname)
+        fabric.contrib.files.sed(
+            app_config_file,
+            "include includes/maintenance.conf",
+            "set $maintenance 1",
+            use_sudo=True,
+            backup=".maint-bak"
+        )
+    with cd('/etc/nginx/sites-enabled/'):
+        sudo('rm -f *.maint-bak')
+    sudo('service nginx reload')


### PR DESCRIPTION
This allows specific apps to be put into maintenance on the carrenza backend_lb machines.

Details of syntax are in the commit message.﻿
