### PR TITLE
Change Content Publisher Maintenance Mode

### DIFF
--- a/publisher_maintenance.py
+++ b/publisher_maintenance.py
@@ -39,10 +39,7 @@ def enable_maintenance(*app_list):
     for app in app_list:
         app_hostname = "{}.{}".format(app, env_url_post)
         app_config_file = "/etc/nginx/sites-enabled/{}".format(app_hostname)
-        if app == "content-publisher":
-            maintenance_setting = "limit_except GET { deny all; }"
-        else:
-            maintenance_setting = "set $maintenance 1;"
+        maintenance_setting = "set $maintenance 1;"
         fabric.contrib.files.sed(
             app_config_file,
             "include includes/maintenance.conf;",


### PR DESCRIPTION
The Developers have said it would be better to put Content Publisher in
maintenance mode during the migration rather than have it in a GET only mode.
It is different from Whitehall in the sense that other APIs do not access the
content/assets created by it. Content Publisher is instead only accessed
through it's user interface.