### PR TITLE
Deprecate repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# DEPRECATED
+
+This repository is no longer maintained.
+These scripts should not be used to administer GOV.UK servers.
+
 # GOV.UK Fabric Scripts
 
 [Fabric](http://fabfile.org) is a command-line tool for application deployment


### PR DESCRIPTION
[Trello](https://trello.com/c/AGdifoDb/250-remove-fabric-and-replace-references-in-docs)

Fabric used to usefully let us apply an ssh command across lots of
machines. However in recent years the tool has become almost impossible
to install.

It relies on an old an deprecated form of pyhton, and its dependencies
cannot be installed today in a way that function.

A quick check of GOV.UK developers show that many no longer attempt to
use the tool, and instead attempt to SSH directly and run the commands.

It is still recommended as a command in numerous places is GOV.UK
developer documentation, causing confusion for 2ndline shifts which are
unable to use the tool.

As such we should deprecate this, keeping the archived repository to
look up commands we used to run with `fab` and translating the docs to
more useful / up to date commands as soon as possible.